### PR TITLE
fix(worker): bound content publish runs

### DIFF
--- a/tests/contentPublishWorker.test.js
+++ b/tests/contentPublishWorker.test.js
@@ -62,4 +62,42 @@ describe('Content Publish Worker', () => {
         expect((await ScheduledContent.findById(alreadyPublished._id)).status).toBe('published');
         expect((await ScheduledContent.findById(cancelled._id)).status).toBe('cancelled');
     });
+
+    it('respects the configured batch size for large due backlogs', async () => {
+        const userId = new mongoose.Types.ObjectId();
+        const dueItems = await ScheduledContent.insertMany([
+            {
+                userId,
+                caption: 'Backlog item 1',
+                timezone: 'UTC',
+                scheduledAt: new Date(Date.now() - 3 * 60 * 1000),
+                status: 'scheduled',
+            },
+            {
+                userId,
+                caption: 'Backlog item 2',
+                timezone: 'UTC',
+                scheduledAt: new Date(Date.now() - 2 * 60 * 1000),
+                status: 'scheduled',
+            },
+            {
+                userId,
+                caption: 'Backlog item 3',
+                timezone: 'UTC',
+                scheduledAt: new Date(Date.now() - 60 * 1000),
+                status: 'scheduled',
+            },
+        ]);
+
+        const publishedCount = await publishDueContent({ batchSize: 2 });
+
+        expect(publishedCount).toBe(2);
+
+        const refreshed = await ScheduledContent.find({
+            _id: { $in: dueItems.map((item) => item._id) },
+        }).sort({ scheduledAt: 1 });
+
+        expect(refreshed.filter((item) => item.status === 'published')).toHaveLength(2);
+        expect(refreshed.filter((item) => item.status === 'scheduled')).toHaveLength(1);
+    });
 });

--- a/workers/contentPublishWorker.js
+++ b/workers/contentPublishWorker.js
@@ -2,13 +2,20 @@ const cron = require('node-cron');
 const ScheduledContent = require('../model/scheduledContent');
 
 const INSTANCE_ID = process.env.INSTANCE_ID || `web-${process.pid}`;
+const DEFAULT_PUBLISH_BATCH_SIZE = 100;
 
-async function publishDueContent() {
+function getPublishBatchSize() {
+    const parsed = Number.parseInt(process.env.CONTENT_PUBLISH_BATCH_SIZE, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_PUBLISH_BATCH_SIZE;
+}
+
+async function publishDueContent(options = {}) {
     const now = new Date();
+    const batchSize = options.batchSize || getPublishBatchSize();
     let publishedCount = 0;
 
     // Use atomic findOneAndUpdate to prevent race conditions in multi-instance deployments
-    while (true) {
+    while (publishedCount < batchSize) {
         const result = await ScheduledContent.findOneAndUpdate(
             {
                 status: 'scheduled',
@@ -23,6 +30,7 @@ async function publishDueContent() {
             },
             {
                 new: true,
+                sort: { scheduledAt: 1, _id: 1 },
             }
         );
 
@@ -41,7 +49,15 @@ function startContentPublishWorker() {
     // Schedule the job to run every minute.
     // The `fireOnStart` option is false by default, so it will wait for the
     // first minute to tick over before its initial run.
+    let isPublishing = false;
+
     cron.schedule('* * * * *', async () => {
+        if (isPublishing) {
+            console.warn('[ContentPublishWorker] Previous publish run is still active; skipping this tick.');
+            return;
+        }
+
+        isPublishing = true;
         try {
             const publishedCount = await publishDueContent();
             if (publishedCount > 0) {
@@ -49,8 +65,10 @@ function startContentPublishWorker() {
             }
         } catch (error) {
             console.error('[ContentPublishWorker] Failed to publish due content:', error.message);
+        } finally {
+            isPublishing = false;
         }
     });
 }
 
-module.exports = { startContentPublishWorker, publishDueContent };
+module.exports = { startContentPublishWorker, publishDueContent, getPublishBatchSize, DEFAULT_PUBLISH_BATCH_SIZE };


### PR DESCRIPTION
## Summary

- add a configurable per-run batch limit to scheduled content publishing
- claim oldest due scheduled content first
- prevent overlapping cron ticks within the same process
- extend worker coverage for due backlog batch limits

## Why

The publish worker previously drained an unlimited backlog in one tick and allowed a new cron tick to start while a slow previous run was still active. Bounded runs make the worker more predictable under load.

Fixes #579

## Testing

- npm test -- tests/contentPublishWorker.test.js --runInBand --forceExit
- npm run build