### PR TITLE
fix(test): support mock url query chaining

### DIFF
--- a/model/url.js
+++ b/model/url.js
@@ -72,8 +72,10 @@ const mockUrls = [];
 
 class MockUrlModel {
     constructor(data) {
+        this._id = data._id || new mongoose.Types.ObjectId();
         this.shortId = data.shortId;
         this.redirectUrl = data.redirectUrl;
+        this.userId = data.userId;
         this.campaignName = data.campaignName || "Untitled Campaign";
         this.totalClicks = data.totalClicks || 0;
         this.qrFgColor = data.qrFgColor || "#1a1a1a";
@@ -125,13 +127,11 @@ class MockUrlModel {
         return new MockUrlModel(found);
     }
 
-    static async find(query = {}) {
-        let results = mockUrls.filter((u) =>
-            Object.entries(query).every(([k, v]) => u[k] === v)
+    static find(query = {}) {
+        const results = mockUrls.filter((u) =>
+            Object.entries(query).every(([k, v]) => u[k]?.toString?.() === v?.toString?.())
         );
-        return {
-            sort: () => results.map((u) => new MockUrlModel(u))
-        };
+        return createMockUrlQuery(results);
     }
 
     static async findByIdAndDelete(id) {
@@ -160,6 +160,40 @@ class MockUrlModel {
             .slice(0, limit)
             .map((u) => new MockUrlModel(u));
     }
+}
+
+function createMockUrlQuery(results) {
+    let currentResults = [...results];
+
+    const query = {
+        sort(sortSpec = {}) {
+            const [[field, direction] = []] = Object.entries(sortSpec);
+            if (field) {
+                currentResults = [...currentResults].sort((a, b) => {
+                    const left = a[field];
+                    const right = b[field];
+                    if (left === right) return 0;
+                    return left > right ? direction : -direction;
+                });
+            }
+            return query;
+        },
+        limit(count) {
+            currentResults = currentResults.slice(0, count);
+            return query;
+        },
+        lean() {
+            return Promise.resolve(currentResults.map((u) => ({ ...new MockUrlModel(u) })));
+        },
+        then(resolve, reject) {
+            return Promise.resolve(currentResults.map((u) => new MockUrlModel(u))).then(resolve, reject);
+        },
+        catch(reject) {
+            return Promise.resolve(currentResults.map((u) => new MockUrlModel(u))).catch(reject);
+        },
+    };
+
+    return query;
 }
 
 function getActiveUrlModel() {

--- a/tests/models/urlMockQuery.test.js
+++ b/tests/models/urlMockQuery.test.js
@@ -1,0 +1,53 @@
+process.env.USE_MOCK_DB = "true";
+
+const Url = require("../../model/url");
+
+describe("Mock Url query chaining", () => {
+  const userId = "64b7f1f1f1f1f1f1f1f1f1f1";
+
+  beforeEach(async () => {
+    await Url.deleteMany({ userId });
+  });
+
+  it("supports Mongoose-style sort, limit, and lean chaining", async () => {
+    await Url.create({
+      userId,
+      shortId: "old",
+      redirectUrl: "https://example.com/old",
+      createdAt: new Date("2026-07-20T00:00:00.000Z"),
+    });
+    await Url.create({
+      userId,
+      shortId: "middle",
+      redirectUrl: "https://example.com/middle",
+      createdAt: new Date("2026-07-21T00:00:00.000Z"),
+    });
+    await Url.create({
+      userId,
+      shortId: "new",
+      redirectUrl: "https://example.com/new",
+      createdAt: new Date("2026-07-22T00:00:00.000Z"),
+    });
+
+    const results = await Url.find({ userId })
+      .sort({ createdAt: -1 })
+      .limit(2)
+      .lean();
+
+    expect(results.map((url) => url.shortId)).toEqual(["new", "middle"]);
+  });
+
+  it("supports awaiting a sorted query without lean", async () => {
+    await Url.create({
+      userId,
+      shortId: "first",
+      redirectUrl: "https://example.com/first",
+      createdAt: new Date("2026-07-20T00:00:00.000Z"),
+    });
+
+    const results = await Url.find({ userId }).sort({ createdAt: -1 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].shortId).toBe("first");
+  });
+});


### PR DESCRIPTION
## Summary

- make the mock Url.find return a Mongoose-style chainable query object
- support sort, limit, lean, and await behavior in mock DB mode
- preserve _id and userId on mock URL records
- add model coverage for chained mock queries

## Why

Controllers use Url.find(...).sort(...).limit(...).lean(), but the mock URL model returned a Promise with only a partial sort stub. This made mock DB mode diverge from production Mongoose behavior.

Fixes #583

## Testing

- npm test -- tests/models/urlMockQuery.test.js --runInBand --forceExit
- npm run build