### PR TITLE
fix(instagram): validate dm trigger payloads

### DIFF
--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -53,6 +53,19 @@ const suggestionSchema = z.object({
   topic: z.string().min(1, 'Topic is required'),
 });
 
+const dmTriggerSchema = z.object({
+  keyword: z.string().trim().min(1, 'Keyword is required').max(80, 'Keyword must be at most 80 characters').transform(value => value.toLowerCase()),
+  responseUrl: z.string().trim().url('Response URL must be valid').refine((value) => {
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }, 'Response URL must use HTTP or HTTPS'),
+  isActive: z.boolean().optional(),
+});
+
 const updateProfileSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100, 'Name must be at most 100 characters').optional(),
   alias: z.string().min(1, 'Alias is required').max(50, 'Alias must be at most 50 characters').regex(/^[a-zA-Z0-9_-]+$/, 'Alias can only contain letters, numbers, hyphens and underscores').optional(),
@@ -94,6 +107,7 @@ module.exports = {
     urlShortenSchema,
     urlQRColorsSchema,
     suggestionSchema,
+    dmTriggerSchema,
     updateProfileSchema,
     objectIdParamSchema,
     shortIdParamSchema,
@@ -106,5 +120,6 @@ module.exports = {
     shortenUrlValidator: validate(urlShortenSchema, 'body'),
     updateQrColorsValidator: validate(urlQRColorsSchema, 'body'),
     inviteCollaboratorValidator: validate(collaborationInviteSchema, 'body'),
-    generateSuggestionValidator: validate(suggestionSchema, 'body')
+    generateSuggestionValidator: validate(suggestionSchema, 'body'),
+    dmTriggerValidator: validate(dmTriggerSchema, 'body')
 };

--- a/routes/instagram.js
+++ b/routes/instagram.js
@@ -6,6 +6,7 @@ const router = express.Router();
 
 const { protect } = require('../middleware/auth');
 const { instagramProfileLimiter } = require('../middleware/rateLimiters');
+const { dmTriggerValidator } = require('../middleware/validators');
 
 /**
  * @swagger
@@ -34,7 +35,7 @@ router.get('/triggers', protect, asyncHandler(async (req, res) => {
     res.json({ success: true, data: triggers });
 }));
 
-router.post('/triggers', protect, asyncHandler(async (req, res) => {
+router.post('/triggers', protect, dmTriggerValidator, asyncHandler(async (req, res) => {
     const trigger = await DmTrigger.create({ ...req.body, creatorId: req.user._id });
     res.status(201).json({ success: true, data: trigger });
 }));

--- a/tests/routes/dmTriggerValidation.test.js
+++ b/tests/routes/dmTriggerValidation.test.js
@@ -1,0 +1,76 @@
+const express = require("express");
+const request = require("supertest");
+
+jest.mock("../../middleware/auth", () => ({
+  protect: (req, res, next) => {
+    req.user = { _id: "64b7f1f1f1f1f1f1f1f1f1f1" };
+    next();
+  },
+}));
+
+jest.mock("../../middleware/rateLimiters", () => ({
+  instagramProfileLimiter: (req, res, next) => next(),
+}));
+
+jest.mock("../../controller/instagramController", () => ({
+  getInstagramProfile: jest.fn((req, res) => res.json({ success: true })),
+}));
+
+jest.mock("../../controller/instagramWebhookController", () => ({
+  verifyWebhook: jest.fn((req, res) => res.sendStatus(200)),
+  verifyWebhookSignature: jest.fn((req, res, next) => next()),
+  handleWebhook: jest.fn((req, res) => res.sendStatus(200)),
+}));
+
+jest.mock("../../model/dmTrigger", () => ({
+  find: jest.fn().mockResolvedValue([]),
+  create: jest.fn(),
+  findOneAndDelete: jest.fn(),
+}));
+
+const DmTrigger = require("../../model/dmTrigger");
+const instagramRoutes = require("../../routes/instagram");
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/instagram", instagramRoutes);
+  return app;
+}
+
+describe("DM trigger payload validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects non-http response URLs", async () => {
+    const res = await request(createApp())
+      .post("/api/instagram/triggers")
+      .send({ keyword: "guide", responseUrl: "ftp://example.com/guide" });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe("Response URL must use HTTP or HTTPS");
+    expect(DmTrigger.create).not.toHaveBeenCalled();
+  });
+
+  it("normalizes valid trigger payloads before create", async () => {
+    DmTrigger.create.mockImplementation(async (payload) => payload);
+
+    const res = await request(createApp())
+      .post("/api/instagram/triggers")
+      .send({
+        keyword: "  GUIDE  ",
+        responseUrl: " https://example.com/guide ",
+        isActive: true,
+        creatorId: "attempted-override",
+      });
+
+    expect(res.statusCode).toBe(201);
+    expect(DmTrigger.create).toHaveBeenCalledWith({
+      keyword: "guide",
+      responseUrl: "https://example.com/guide",
+      isActive: true,
+      creatorId: "64b7f1f1f1f1f1f1f1f1f1f1",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add request validation for Instagram DM trigger creation
- normalize keywords and trim response URLs
- require HTTP or HTTPS response URLs
- strip unexpected fields before creating trigger records
- add route coverage for invalid and valid trigger payloads

## Why

The trigger create route passed the request body directly into the model. Validating at the route boundary keeps malformed trigger data and unexpected fields out of persisted records.

Fixes #609

## Testing

- npm test -- tests/routes/dmTriggerValidation.test.js --runInBand --forceExit
- npm run build