### PR TITLE
fix(sponsors): allowlist update fields

### DIFF
--- a/controller/sponsor.js
+++ b/controller/sponsor.js
@@ -1,6 +1,24 @@
 const asyncHandler = require("../utils/asyncHandler");
 const Sponsor = require("../model/sponsor");
 
+const SPONSOR_UPDATE_FIELDS = [
+    "companyName",
+    "contactName",
+    "contactEmail",
+    "status",
+    "value",
+    "notes",
+];
+
+function buildSponsorUpdate(body = {}) {
+    return SPONSOR_UPDATE_FIELDS.reduce((update, field) => {
+        if (body[field] !== undefined) {
+            update[field] = body[field];
+        }
+        return update;
+    }, {});
+}
+
 const getSponsors = asyncHandler(async (req, res) => {
     const sponsors = await Sponsor.find({ creatorId: req.user._id }).sort({ createdAt: -1 });
     res.json({ success: true, data: sponsors });
@@ -12,9 +30,15 @@ const createSponsor = asyncHandler(async (req, res) => {
 });
 
 const updateSponsor = asyncHandler(async (req, res) => {
+    const update = buildSponsorUpdate(req.body);
+
+    if (Object.keys(update).length === 0) {
+        return res.status(400).json({ success: false, message: "No valid sponsor fields provided" });
+    }
+
     const sponsor = await Sponsor.findOneAndUpdate(
         { _id: req.params.id, creatorId: req.user._id },
-        req.body,
+        { $set: update },
         { new: true, runValidators: true }
     );
     if (!sponsor) return res.status(404).json({ success: false, message: "Sponsor not found" });
@@ -31,5 +55,6 @@ module.exports = {
     getSponsors,
     createSponsor,
     updateSponsor,
-    deleteSponsor
+    deleteSponsor,
+    buildSponsorUpdate
 };

--- a/tests/controllers/sponsorUpdate.test.js
+++ b/tests/controllers/sponsorUpdate.test.js
@@ -1,0 +1,72 @@
+jest.mock("../../model/sponsor", () => ({
+  findOneAndUpdate: jest.fn(),
+}));
+
+const Sponsor = require("../../model/sponsor");
+const { updateSponsor, buildSponsorUpdate } = require("../../controller/sponsor");
+
+function createResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+}
+
+describe("sponsor update allowlist", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("drops protected fields from update payloads", () => {
+    expect(buildSponsorUpdate({
+      companyName: "Acme",
+      creatorId: "attacker-id",
+      createdAt: "2026-01-01",
+      status: "negotiating",
+    })).toEqual({
+      companyName: "Acme",
+      status: "negotiating",
+    });
+  });
+
+  it("updates only allowlisted fields", async () => {
+    Sponsor.findOneAndUpdate.mockResolvedValue({ companyName: "Acme" });
+    const req = {
+      params: { id: "sponsor-id" },
+      user: { _id: "user-id" },
+      body: {
+        companyName: "Acme",
+        creatorId: "other-user",
+        updatedAt: "2026-01-01",
+      },
+    };
+    const res = createResponse();
+
+    await updateSponsor(req, res, jest.fn());
+
+    expect(Sponsor.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: "sponsor-id", creatorId: "user-id" },
+      { $set: { companyName: "Acme" } },
+      { new: true, runValidators: true }
+    );
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: { companyName: "Acme" } });
+  });
+
+  it("rejects updates without editable fields", async () => {
+    const req = {
+      params: { id: "sponsor-id" },
+      user: { _id: "user-id" },
+      body: { creatorId: "other-user" },
+    };
+    const res = createResponse();
+
+    await updateSponsor(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "No valid sponsor fields provided",
+    });
+    expect(Sponsor.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add a sponsor update allowlist for editable CRM fields
- update sponsors with  instead of passing the raw request body
- reject update requests that contain no editable fields
- add controller coverage for protected fields and empty updates

## Why

The sponsor update endpoint accepted req.body directly, allowing protected fields such as creatorId or timestamps to reach the update document. Building an allowlisted update prevents ownership corruption.

Fixes #610

## Testing

- npm test -- tests/controllers/sponsorUpdate.test.js --runInBand --forceExit
- npm run build