### PR TITLE
fix(rate-limit): normalize instagram cooldown config

### DIFF
--- a/controller/instagramController.js
+++ b/controller/instagramController.js
@@ -1,4 +1,5 @@
 const { fetchInstagramProfile, InstagramProfileError, validateUsername } = require('../utils/instagramProfileService');
+const { getInstagramLookupCooldownSeconds } = require('../utils/instagramCooldown');
 const { createRedisClient } = require('../utils/redisClient');
 
 const redis = createRedisClient();
@@ -16,8 +17,7 @@ if (redis?.on) {
  * @returns {any}
  */
 function getCooldownSeconds() {
-    const value = Number(process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS || 30);
-    return Number.isFinite(value) && value >= 0 ? value : 30;
+    return getInstagramLookupCooldownSeconds({ allowZero: true });
 }
 
 /**

--- a/middleware/rateLimiters.js
+++ b/middleware/rateLimiters.js
@@ -1,6 +1,7 @@
 const { ipKeyGenerator, rateLimit } = require('express-rate-limit');
 const { wantsHtml } = require('../utils/requestType');
 const { buildShortenerViewModel } = require('../utils/viewModels');
+const { getInstagramLookupCooldownSeconds } = require('../utils/instagramCooldown');
 const MongoStore = require('rate-limit-mongo');
 
 function shouldUseMongoStore() {
@@ -112,20 +113,22 @@ const aiGenerationLimiter = rateLimit({
         return res.status(429).json({ success: false, message, error: message });
     }
 });
+const instagramLookupCooldownSeconds = getInstagramLookupCooldownSeconds();
+
 const instagramProfileLimiter = rateLimit({
-    windowMs: (process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS || 30) * 1000,
+    windowMs: instagramLookupCooldownSeconds * 1000,
     max: 1,
     keyGenerator: keyByUserOrIp,
     store: shouldUseMongoStore() ? new MongoStore({
         uri: process.env.MONGODB_URI,
-        expireTimeMs: (process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS || 30) * 1000,
+        expireTimeMs: instagramLookupCooldownSeconds * 1000,
     }) : undefined,
     handler: (req, res) => {
         return res.status(429).json({
             success: false,
             error: {
                 code: 'RATE_LIMITED',
-                message: `Please wait ${process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS || 30} seconds before fetching another Instagram profile.`,
+                message: `Please wait ${instagramLookupCooldownSeconds} seconds before fetching another Instagram profile.`,
             }
         });
     }

--- a/tests/utils/instagramCooldown.test.js
+++ b/tests/utils/instagramCooldown.test.js
@@ -1,0 +1,47 @@
+const {
+    DEFAULT_INSTAGRAM_LOOKUP_COOLDOWN_SECONDS,
+    getInstagramLookupCooldownSeconds,
+} = require('../../utils/instagramCooldown');
+
+describe('instagram cooldown config', () => {
+    const originalValue = process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS;
+
+    afterEach(() => {
+        if (originalValue === undefined) {
+            delete process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS;
+        } else {
+            process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS = originalValue;
+        }
+    });
+
+    test('uses the default when the env var is missing', () => {
+        delete process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS;
+
+        expect(getInstagramLookupCooldownSeconds()).toBe(DEFAULT_INSTAGRAM_LOOKUP_COOLDOWN_SECONDS);
+    });
+
+    test('uses the default for invalid values', () => {
+        process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS = 'not-a-number';
+
+        expect(getInstagramLookupCooldownSeconds()).toBe(DEFAULT_INSTAGRAM_LOOKUP_COOLDOWN_SECONDS);
+    });
+
+    test('uses the default for negative values', () => {
+        process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS = '-5';
+
+        expect(getInstagramLookupCooldownSeconds()).toBe(DEFAULT_INSTAGRAM_LOOKUP_COOLDOWN_SECONDS);
+    });
+
+    test('uses the default for zero unless explicitly allowed', () => {
+        process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS = '0';
+
+        expect(getInstagramLookupCooldownSeconds()).toBe(DEFAULT_INSTAGRAM_LOOKUP_COOLDOWN_SECONDS);
+        expect(getInstagramLookupCooldownSeconds({ allowZero: true })).toBe(0);
+    });
+
+    test('returns positive numeric values', () => {
+        process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS = '45';
+
+        expect(getInstagramLookupCooldownSeconds()).toBe(45);
+    });
+});

--- a/utils/instagramCooldown.js
+++ b/utils/instagramCooldown.js
@@ -1,0 +1,21 @@
+const DEFAULT_INSTAGRAM_LOOKUP_COOLDOWN_SECONDS = 30;
+
+function getInstagramLookupCooldownSeconds(options = {}) {
+    const { allowZero = false } = options;
+    const value = Number(process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS);
+
+    if (Number.isFinite(value) && value > 0) {
+        return value;
+    }
+
+    if (allowZero && value === 0) {
+        return 0;
+    }
+
+    return DEFAULT_INSTAGRAM_LOOKUP_COOLDOWN_SECONDS;
+}
+
+module.exports = {
+    DEFAULT_INSTAGRAM_LOOKUP_COOLDOWN_SECONDS,
+    getInstagramLookupCooldownSeconds,
+};


### PR DESCRIPTION
## Summary
- add a shared parser for Instagram lookup cooldown configuration
- keep the Express rate limiter on a valid positive fallback window
- preserve the controller's explicit zero-disable behavior
- add config coverage for missing, invalid, negative, zero, and valid values

## Why
Invalid or zero cooldown values could be passed into the rate limiter window, producing invalid limiter behavior at startup. Normalizing the value before building the limiter keeps the configuration safe while preserving the controller behavior.

Fixes #611

## Testing
- npm test -- tests/utils/instagramCooldown.test.js --runInBand --forceExit
- npm run build