### PR TITLE
fix(settings): validate preference updates

### DIFF
--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -59,6 +59,14 @@ const updateProfileSchema = z.object({
   bio: z.string().max(500, 'Bio must be at most 500 characters').optional(),
 });
 
+const preferencesSchema = z.object({
+  appearanceMode: z.enum(['light', 'dark', 'system']).optional(),
+  interfaceDensity: z.enum(['compact', 'tactile']).optional(),
+  motionEffects: z.boolean().optional(),
+  soundCues: z.boolean().optional(),
+  autoSaveLinks: z.boolean().optional(),
+}).strict();
+
 const objectIdParamSchema = z.object({
   creatorId: z.string().regex(/^[a-f\d]{24}$/i, 'Invalid creatorId'),
 });
@@ -95,6 +103,7 @@ module.exports = {
     urlQRColorsSchema,
     suggestionSchema,
     updateProfileSchema,
+    preferencesSchema,
     objectIdParamSchema,
     shortIdParamSchema,
     validate,

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -4,7 +4,7 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const User = require('../model/user');
 const { preventContributorWrites } = require('../middleware/auth');
-const { validate, updateProfileSchema } = require('../middleware/validators');
+const { validate, updateProfileSchema, preferencesSchema } = require('../middleware/validators');
 
 const asyncHandler = fn => (req, res, next) =>
     Promise.resolve(fn(req, res, next)).catch(next);
@@ -496,7 +496,7 @@ router.delete('/account', preventContributorWrites, asyncHandler(async (req, res
  *       500:
  *         description: Internal server error
  */
-router.put('/preferences', asyncHandler(async (req, res) => {
+router.put('/preferences', validate(preferencesSchema, 'body'), asyncHandler(async (req, res) => {
     // Note: Not using preventContributorWrites here so contributors can still save personal UI preferences
     const preferences = req.body;
     

--- a/tests/middleware/preferencesSchema.test.js
+++ b/tests/middleware/preferencesSchema.test.js
@@ -1,0 +1,33 @@
+const { preferencesSchema } = require('../../middleware/validators');
+
+describe('preferencesSchema', () => {
+    test('accepts valid partial preference updates', () => {
+        const result = preferencesSchema.safeParse({
+            appearanceMode: 'dark',
+            motionEffects: false,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({
+            appearanceMode: 'dark',
+            motionEffects: false,
+        });
+    });
+
+    test('rejects invalid enum values', () => {
+        const result = preferencesSchema.safeParse({
+            appearanceMode: 'neon',
+        });
+
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects unknown keys and string booleans', () => {
+        const result = preferencesSchema.safeParse({
+            soundCues: 'false',
+            extra: 'field',
+        });
+
+        expect(result.success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- add a strict preferences schema for settings updates
- reject invalid preference enum values, unknown keys, and string booleans
- wire the schema into the preferences endpoint
- add focused schema coverage

## Why
The preferences endpoint merged raw request bodies into the user document. Validating the allowed preference shape prevents unsupported values from being persisted.

Fixes #667

## Testing
- npm test -- tests/middleware/preferencesSchema.test.js --runInBand --forceExit
- npm run build