### PR TITLE
fix(settings): validate two factor toggle

### DIFF
--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -59,6 +59,10 @@ const updateProfileSchema = z.object({
   bio: z.string().max(500, 'Bio must be at most 500 characters').optional(),
 });
 
+const twoFactorSchema = z.object({
+  enabled: z.boolean({ invalid_type_error: 'enabled must be a boolean' }),
+}).strict();
+
 const objectIdParamSchema = z.object({
   creatorId: z.string().regex(/^[a-f\d]{24}$/i, 'Invalid creatorId'),
 });
@@ -95,6 +99,7 @@ module.exports = {
     urlQRColorsSchema,
     suggestionSchema,
     updateProfileSchema,
+    twoFactorSchema,
     objectIdParamSchema,
     shortIdParamSchema,
     validate,

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -4,7 +4,7 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const User = require('../model/user');
 const { preventContributorWrites } = require('../middleware/auth');
-const { validate, updateProfileSchema } = require('../middleware/validators');
+const { validate, updateProfileSchema, twoFactorSchema } = require('../middleware/validators');
 
 const asyncHandler = fn => (req, res, next) =>
     Promise.resolve(fn(req, res, next)).catch(next);
@@ -131,13 +131,13 @@ router.get('/billing', asyncHandler(async (req, res) => {
  *       500:
  *         description: Internal server error
  */
-router.put('/security/2fa', preventContributorWrites, asyncHandler(async (req, res) => {
+router.put('/security/2fa', preventContributorWrites, validate(twoFactorSchema, 'body'), asyncHandler(async (req, res) => {
     const { enabled } = req.body;
     
     const user = await User.findById(req.user.id);
     if (!user) return res.status(404).json({ error: 'User not found' });
     
-    user.twoFactorEnabled = !!enabled;
+    user.twoFactorEnabled = enabled;
     await user.save();
     
     res.json({ message: '2FA settings updated successfully', twoFactorEnabled: user.twoFactorEnabled });

--- a/tests/middleware/twoFactorSchema.test.js
+++ b/tests/middleware/twoFactorSchema.test.js
@@ -1,0 +1,20 @@
+const { twoFactorSchema } = require('../../middleware/validators');
+
+describe('twoFactorSchema', () => {
+    test('accepts boolean true and false values', () => {
+        expect(twoFactorSchema.safeParse({ enabled: true }).success).toBe(true);
+        expect(twoFactorSchema.safeParse({ enabled: false }).success).toBe(true);
+    });
+
+    test('rejects string boolean values', () => {
+        const result = twoFactorSchema.safeParse({ enabled: 'false' });
+
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects unknown fields', () => {
+        const result = twoFactorSchema.safeParse({ enabled: false, role: 'admin' });
+
+        expect(result.success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- add a strict schema for 2FA toggle requests
- require `enabled` to be a real boolean
- assign the validated value directly instead of coercing with truthiness
- add schema coverage for booleans, string booleans, and unknown fields

## Why
The previous `!!enabled` coercion treated string values such as `false` as enabled. Validating the request prevents accidental 2FA state changes.

Fixes #668

## Testing
- npm test -- tests/middleware/twoFactorSchema.test.js --runInBand --forceExit
- npm run build