### PR TITLE
fix(domain): normalize custom domain input

### DIFF
--- a/routes/domain.js
+++ b/routes/domain.js
@@ -3,6 +3,7 @@ const dns = require("dns").promises;
 const User = require("../model/user");
 const { protect } = require("../middleware/auth");
 const asyncHandler = require("../utils/asyncHandler");
+const { normalizeCustomDomain } = require("../utils/customDomain");
 
 const router = express.Router();
 
@@ -30,10 +31,10 @@ const router = express.Router();
  *         description: Domain verification failed
  */
 router.post("/verify", protect, asyncHandler(async (req, res) => {
-    const { domain } = req.body;
+    const domain = normalizeCustomDomain(req.body?.domain);
     
     if (!domain) {
-        return res.status(400).json({ success: false, message: "Domain is required" });
+        return res.status(400).json({ success: false, message: "A valid domain is required" });
     }
 
     try {
@@ -45,7 +46,7 @@ router.post("/verify", protect, asyncHandler(async (req, res) => {
         const isVerified = records.includes("cname.creatoros.com") || process.env.NODE_ENV !== "production";
 
         if (isVerified) {
-            await User.findByIdAndUpdate(req.user._id, { customDomain: domain, domainVerified: true });
+            await User.findByIdAndUpdate(req.user.id || req.user._id, { customDomain: domain, domainVerified: true });
             return res.json({ success: true, message: "Domain verified successfully" });
         } else {
             return res.status(400).json({ success: false, message: "Domain DNS records are not pointing correctly" });
@@ -53,7 +54,7 @@ router.post("/verify", protect, asyncHandler(async (req, res) => {
     } catch (error) {
         // If dns lookup fails in dev, mock success to allow progression
         if (process.env.NODE_ENV !== "production") {
-            await User.findByIdAndUpdate(req.user._id, { customDomain: domain, domainVerified: true });
+            await User.findByIdAndUpdate(req.user.id || req.user._id, { customDomain: domain, domainVerified: true });
             return res.json({ success: true, message: "Domain verified successfully (mock)" });
         }
         return res.status(400).json({ success: false, message: "Failed to resolve domain" });

--- a/tests/utils/customDomain.test.js
+++ b/tests/utils/customDomain.test.js
@@ -1,0 +1,22 @@
+const { normalizeCustomDomain } = require('../../utils/customDomain');
+
+describe('normalizeCustomDomain', () => {
+    test('trims and lowercases hostnames', () => {
+        expect(normalizeCustomDomain(' Example.COM ')).toBe('example.com');
+    });
+
+    test('removes a trailing root dot', () => {
+        expect(normalizeCustomDomain('creator.example.com.')).toBe('creator.example.com');
+    });
+
+    test('rejects URL-shaped input', () => {
+        expect(normalizeCustomDomain('https://example.com/path')).toBeNull();
+        expect(normalizeCustomDomain('example.com/path')).toBeNull();
+    });
+
+    test('rejects empty and malformed domains', () => {
+        expect(normalizeCustomDomain('   ')).toBeNull();
+        expect(normalizeCustomDomain('localhost')).toBeNull();
+        expect(normalizeCustomDomain('-example.com')).toBeNull();
+    });
+});

--- a/utils/customDomain.js
+++ b/utils/customDomain.js
@@ -1,0 +1,15 @@
+const DOMAIN_PATTERN = /^(?=.{1,253}$)(?!-)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/;
+
+function normalizeCustomDomain(value) {
+    if (typeof value !== "string") return null;
+
+    const domain = value.trim().toLowerCase().replace(/\.$/, "");
+    if (!domain) return null;
+    if (domain.includes("://") || /[/?#]/.test(domain)) return null;
+
+    return DOMAIN_PATTERN.test(domain) ? domain : null;
+}
+
+module.exports = {
+    normalizeCustomDomain,
+};


### PR DESCRIPTION
## Summary
- add custom domain normalization and validation
- reject protocol, path, query, and malformed domain input before DNS lookup
- store normalized hostnames on successful verification
- add utility coverage for valid and invalid inputs

## Why
The domain verification route used raw request input for DNS lookup and persistence. Normalizing first keeps stored custom domains consistent and prevents URL-shaped values from being accepted in mock verification paths.

Fixes #669

## Testing
- npm test -- tests/utils/customDomain.test.js --runInBand --forceExit
- npm run build