### PR TITLE
fix(auth): reject verification tokens without expiry

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -62,7 +62,9 @@ function getVerificationTokenExpiry() {
  * @returns {any}
  */
 function isVerificationTokenExpired(expiryDate) {
-    return expiryDate < new Date();
+    if (!expiryDate) return true;
+    const expiryTime = new Date(expiryDate).getTime();
+    return Number.isNaN(expiryTime) || expiryTime < Date.now();
 }
 /**
  * @function isGoogleAuthConfigured
@@ -724,4 +726,5 @@ module.exports = {
     resendVerificationEmail,
     requestPasswordReset,
     resetPassword,
+    isVerificationTokenExpired,
 };

--- a/tests/controllers/verificationTokenExpiry.test.js
+++ b/tests/controllers/verificationTokenExpiry.test.js
@@ -1,0 +1,33 @@
+jest.mock('../../connect', () => jest.fn());
+jest.mock('../../utils/email', () => ({
+    isEmailTransportConfigured: jest.fn(() => true),
+}));
+jest.mock('../../utils/loginAttemptManager', () => ({
+    checkIfLoginLocked: jest.fn(),
+    recordFailedLoginAttempt: jest.fn(),
+    clearLoginAttempts: jest.fn(),
+    getRemainingLoginLockoutTime: jest.fn(),
+    checkIfResetLocked: jest.fn(),
+    recordFailedResetAttempt: jest.fn(),
+    clearResetAttempts: jest.fn(),
+    getRemainingResetLockoutTime: jest.fn(),
+}));
+
+const { isVerificationTokenExpired } = require('../../controller/auth');
+
+describe('isVerificationTokenExpired', () => {
+    test('treats missing expiry values as expired', () => {
+        expect(isVerificationTokenExpired(undefined)).toBe(true);
+        expect(isVerificationTokenExpired(null)).toBe(true);
+    });
+
+    test('treats invalid expiry values as expired', () => {
+        expect(isVerificationTokenExpired('not-a-date')).toBe(true);
+    });
+
+    test('accepts future expiry values', () => {
+        const future = new Date(Date.now() + 60_000);
+
+        expect(isVerificationTokenExpired(future)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- treat missing verification-token expiry values as expired
- reject invalid expiry values instead of verifying the account
- add focused coverage for missing, invalid, and future expiry values

## Why
Verification tokens should require a valid expiry timestamp. Without this guard, malformed user records with a token but no expiry could be verified indefinitely.

Fixes #687

## Testing
- npm test -- tests/controllers/verificationTokenExpiry.test.js --runInBand --forceExit
- npm run build