### PR TITLE
fix(content): limit scheduled caption length

### DIFF
--- a/controller/contentController.js
+++ b/controller/contentController.js
@@ -2,6 +2,8 @@ const mongoose = require('mongoose');
 const asyncHandler = require('../utils/asyncHandler');
 const ScheduledContent = require('../model/scheduledContent');
 
+const MAX_SCHEDULED_CAPTION_LENGTH = 2200;
+
 /**
  * @function scheduleContent
  * @description Creates a piece of content scheduled to auto-publish at a future UTC time.
@@ -12,8 +14,17 @@ const ScheduledContent = require('../model/scheduledContent');
 const scheduleContent = asyncHandler(async (req, res) => {
     const { caption, mediaUrl, scheduledAt, timezone } = req.body || {};
 
-    if (!caption || typeof caption !== 'string' || !caption.trim()) {
+    const normalizedCaption = typeof caption === 'string' ? caption.trim() : '';
+
+    if (!normalizedCaption) {
         return res.status(400).json({ success: false, message: 'Caption is required' });
+    }
+
+    if (normalizedCaption.length > MAX_SCHEDULED_CAPTION_LENGTH) {
+        return res.status(400).json({
+            success: false,
+            message: `Caption must be ${MAX_SCHEDULED_CAPTION_LENGTH} characters or fewer`,
+        });
     }
 
     if (!scheduledAt) {
@@ -35,7 +46,7 @@ const scheduleContent = asyncHandler(async (req, res) => {
 
     const content = await ScheduledContent.create({
         userId: req.user.id,
-        caption: caption.trim(),
+        caption: normalizedCaption,
         mediaUrl: mediaUrl || undefined,
         timezone: timezone || 'UTC',
         scheduledAt: scheduledDate,
@@ -88,4 +99,4 @@ const cancelScheduledContent = asyncHandler(async (req, res) => {
     return res.json({ success: true, content });
 });
 
-module.exports = { scheduleContent, listScheduledContent, cancelScheduledContent };
+module.exports = { scheduleContent, listScheduledContent, cancelScheduledContent, MAX_SCHEDULED_CAPTION_LENGTH };

--- a/model/scheduledContent.js
+++ b/model/scheduledContent.js
@@ -20,6 +20,7 @@ const scheduledContentSchema = new mongoose.Schema(
             type: String,
             required: true,
             trim: true,
+            maxlength: 2200,
         },
         mediaUrl: {
             type: String,

--- a/tests/controllers/scheduledCaptionLength.test.js
+++ b/tests/controllers/scheduledCaptionLength.test.js
@@ -1,0 +1,14 @@
+const { MAX_SCHEDULED_CAPTION_LENGTH } = require('../../controller/contentController');
+
+describe('scheduled caption length configuration', () => {
+    test('uses the expected caption limit', () => {
+        expect(MAX_SCHEDULED_CAPTION_LENGTH).toBe(2200);
+    });
+
+    test('model schema enforces the same caption limit', () => {
+        const ScheduledContent = require('../../model/scheduledContent');
+        const maxLength = ScheduledContent.schema.path('caption').options.maxlength;
+
+        expect(maxLength).toBe(MAX_SCHEDULED_CAPTION_LENGTH);
+    });
+});


### PR DESCRIPTION
## Summary
- add a 2200-character maximum for scheduled content captions
- validate the trimmed caption before creating scheduled content
- mirror the same maximum on the ScheduledContent schema
- add focused coverage for the shared caption limit

## Why
Scheduled content accepted unbounded captions, which could create oversized database records and response payloads.

Fixes #692

## Testing
- npm test -- tests/controllers/scheduledCaptionLength.test.js --runInBand --forceExit
- npm run build