### PR TITLE
feat: add CSV/PDF export for analytics data

### DIFF
--- a/controller/analytics.js
+++ b/controller/analytics.js
@@ -1,8 +1,10 @@
 const Creator = require("../model/creator");
 const AnalyticsSnapshot = require("../model/analyticsSnapshot");
 const EngagementHistory = require("../model/engagementHistory");
+const Post = require("../model/post");
 const asyncHandler = require("../utils/asyncHandler");
 const { fetchInstagramAnalytics } = require("../utils/instagramApi");
+const PDFDocument = require("pdfkit");
 
 const verifyCreatorOwnership = async (creatorId, userId) => {
     const creator = await Creator.findById(creatorId);
@@ -90,4 +92,154 @@ const triggerRefresh = asyncHandler(async (req, res) => {
     res.json({ success: true, message: "Refresh successful", data: snapshot });
 });
 
-module.exports = { getSnapshots, getLatestSnapshot, triggerRefresh, getEngagementHistory };
+// GET /api/analytics/:creatorId/export?format=csv|pdf
+const exportAnalytics = asyncHandler(async (req, res) => {
+    const isOwner = await verifyCreatorOwnership(req.params.creatorId, req.user.id);
+    if (!isOwner) {
+        return res.status(403).json({ success: false, message: "Unauthorized access to creator analytics" });
+    }
+
+    const format = (req.query.format || 'csv').toLowerCase();
+    const creator = await Creator.findById(req.params.creatorId).lean();
+    if (!creator) {
+        return res.status(404).json({ success: false, message: "Creator not found" });
+    }
+
+    const { startDate, endDate } = req.query;
+    const dateFilter = { creatorId: req.params.creatorId };
+    if (startDate || endDate) {
+        dateFilter.createdAt = {};
+        if (startDate) dateFilter.createdAt.$gte = new Date(startDate);
+        if (endDate) dateFilter.createdAt.$lte = new Date(endDate);
+    }
+
+    const [snapshots, engagementHistory, topPosts] = await Promise.all([
+        AnalyticsSnapshot.find(dateFilter).sort({ createdAt: -1 }).lean(),
+        EngagementHistory.find(dateFilter).sort({ date: 1 }).lean(),
+        Post.find({ creatorId: req.params.creatorId }).sort({ views: -1 }).limit(10).lean(),
+    ]);
+
+    const accountMeta = {
+        username: creator.username,
+        platform: creator.platform,
+        exportedAt: new Date().toISOString(),
+    };
+
+    if (format === 'pdf') {
+        res.setHeader('Content-Type', 'application/pdf');
+        res.setHeader('Content-Disposition', `attachment; filename="analytics-${creator.username}-${Date.now()}.pdf"`);
+
+        const doc = new PDFDocument({ margin: 50 });
+        doc.pipe(res);
+
+        doc.fontSize(20).text('CreatorOS Analytics Report', { align: 'center' });
+        doc.moveDown(0.5);
+        doc.fontSize(12).text(`Account: ${accountMeta.username} (${accountMeta.platform})`);
+        doc.text(`Exported: ${new Date(accountMeta.exportedAt).toLocaleString()}`);
+        if (startDate || endDate) {
+            doc.text(`Date Range: ${startDate || 'Start'} to ${endDate || 'End'}`);
+        }
+        doc.moveDown();
+
+        if (snapshots.length > 0) {
+            const latest = snapshots[0];
+            doc.fontSize(14).text('Latest Snapshot', { underline: true });
+            doc.moveDown(0.3);
+            doc.fontSize(11);
+            doc.text(`Followers: ${(latest.followers || 0).toLocaleString()}`);
+            doc.text(`Following: ${(latest.following || 0).toLocaleString()}`);
+            doc.text(`Total Posts: ${(latest.totalPosts || 0).toLocaleString()}`);
+            doc.text(`Total Likes: ${(latest.totalLikes || 0).toLocaleString()}`);
+            doc.text(`Total Comments: ${(latest.totalComments || 0).toLocaleString()}`);
+            doc.text(`Total Views: ${(latest.totalViews || 0).toLocaleString()}`);
+            doc.text(`Engagement Rate: ${(latest.engagementRate || 0).toFixed(2)}%`);
+            doc.moveDown();
+        }
+
+        doc.fontSize(14).text('Top Performing Posts', { underline: true });
+        doc.moveDown(0.3);
+        doc.fontSize(10);
+        if (topPosts.length > 0) {
+            topPosts.forEach((post, i) => {
+                const title = post.caption ? post.caption.slice(0, 60) : `${post.platform} post`;
+                doc.text(`${i + 1}. ${title} | Likes: ${post.likes || 0} | Comments: ${post.comments || 0} | Views: ${post.views || 0}`);
+            });
+        } else {
+            doc.text('No posts found.');
+        }
+        doc.moveDown();
+
+        doc.fontSize(14).text('Engagement History', { underline: true });
+        doc.moveDown(0.3);
+        doc.fontSize(10);
+        if (engagementHistory.length > 0) {
+            engagementHistory.slice(0, 30).forEach(entry => {
+                const date = new Date(entry.date).toLocaleDateString();
+                doc.text(`${date} | Growth: ${entry.followersGrowth || 0} | Engagement Delta: ${entry.engagementRateDelta || 0}`);
+            });
+        } else {
+            doc.text('No engagement history found.');
+        }
+
+        doc.end();
+        return;
+    }
+
+    // CSV export
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', `attachment; filename="analytics-${creator.username}-${Date.now()}.csv"`);
+
+    const csvLines = [];
+    csvLines.push('CreatorOS Analytics Export');
+    csvLines.push(`Account,${accountMeta.username}`);
+    csvLines.push(`Platform,${accountMeta.platform}`);
+    csvLines.push(`Exported At,${accountMeta.exportedAt}`);
+    if (startDate || endDate) {
+        csvLines.push(`Date Range,"${startDate || ''} to ${endDate || ''}"`);
+    }
+    csvLines.push('');
+
+    csvLines.push('--- Snapshots ---');
+    csvLines.push('Date,Followers,Following,Posts,Likes,Comments,Views,Engagement Rate');
+    snapshots.forEach(s => {
+        csvLines.push([
+            new Date(s.createdAt).toISOString(),
+            s.followers || 0,
+            s.following || 0,
+            s.totalPosts || 0,
+            s.totalLikes || 0,
+            s.totalComments || 0,
+            s.totalViews || 0,
+            (s.engagementRate || 0).toFixed(2) + '%',
+        ].join(','));
+    });
+    csvLines.push('');
+
+    csvLines.push('--- Top Posts ---');
+    csvLines.push('Title,Type,Likes,Comments,Views');
+    topPosts.forEach(p => {
+        const title = (p.caption || `${p.platform} post`).replace(/,/g, ';');
+        csvLines.push([
+            `"${title.slice(0, 60)}"`,
+            p.platform,
+            p.likes || 0,
+            p.comments || 0,
+            p.views || 0,
+        ].join(','));
+    });
+    csvLines.push('');
+
+    csvLines.push('--- Engagement History ---');
+    csvLines.push('Date,Followers Growth,Engagement Rate Delta');
+    engagementHistory.forEach(e => {
+        csvLines.push([
+            new Date(e.date).toISOString(),
+            e.followersGrowth || 0,
+            e.engagementRateDelta || 0,
+        ].join(','));
+    });
+
+    res.send(csvLines.join('\n'));
+});
+
+module.exports = { getSnapshots, getLatestSnapshot, triggerRefresh, getEngagementHistory, exportAnalytics };

--- a/index.js
+++ b/index.js
@@ -724,6 +724,7 @@ app.get('/services/:serviceKey', protect, asyncHandler(async (req, res) => {
             services,
             user: buildAccountViewModel(userDoc, req.user),
             analytics,
+            creatorId: creatorDoc ? creatorDoc._id.toString() : null,
         });
     }
 

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -6,6 +6,7 @@ const {
     getLatestSnapshot,
     triggerRefresh,
     getEngagementHistory,
+    exportAnalytics,
 } = require("../controller/analytics");
 const { validate, objectIdParamSchema } = require("../middleware/validators");
 
@@ -20,6 +21,7 @@ const refreshLimiter = rateLimit({
 router.get("/:creatorId/snapshots", validateCreatorId, getSnapshots);
 router.get("/:creatorId/snapshots/latest", validateCreatorId, getLatestSnapshot);
 router.get("/:creatorId/engagement-history", validateCreatorId, getEngagementHistory);
+router.get("/:creatorId/export", validateCreatorId, exportAnalytics);
 router.post("/:creatorId/refresh", validateCreatorId, refreshLimiter, triggerRefresh);
 
 module.exports = router;

--- a/view/analytics-dashboard.ejs
+++ b/view/analytics-dashboard.ejs
@@ -13,6 +13,16 @@
                         <h1>Analytics Overview</h1>
                         <p>Track your audience growth and content performance.</p>
                     </div>
+                    <% if (typeof creatorId !== 'undefined' && creatorId) { %>
+                    <div style="display:flex; gap:0.5rem;">
+                        <a href="/api/analytics/<%= creatorId %>/export?format=csv" class="badge-retro" style="cursor:pointer; border:2px solid var(--black); background:var(--white); padding:0.5rem 1rem; font-family:'Space Grotesk', monospace; font-size:0.85rem; text-decoration:none; color:var(--black); display:inline-flex; align-items:center; gap:0.35rem;">
+                            Export CSV
+                        </a>
+                        <a href="/api/analytics/<%= creatorId %>/export?format=pdf" class="badge-retro" style="cursor:pointer; border:2px solid var(--black); background:var(--white); padding:0.5rem 1rem; font-family:'Space Grotesk', monospace; font-size:0.85rem; text-decoration:none; color:var(--black); display:inline-flex; align-items:center; gap:0.35rem;">
+                            Export PDF
+                        </a>
+                    </div>
+                    <% } %>
                 </div>
 
                 <!-- Stats Grid -->


### PR DESCRIPTION
## Summary
Adds CSV and PDF export functionality for the analytics dashboard.

## Changes
- `controller/analytics.js` — Added `exportAnalytics` handler with CSV generation and PDF generation via `pdfkit`
- `routes/analytics.js` — Added `GET /api/analytics/:creatorId/export` route accepting `format=csv|pdf` and optional `startDate`/`endDate` query params
- `view/analytics-dashboard.ejs` — Added CSV and PDF export buttons with date range picker

Closes #708