### PR TITLE
feat: bulk content scheduling via CSV upload

### DIFF
--- a/controller/contentController.js
+++ b/controller/contentController.js
@@ -2,6 +2,26 @@ const mongoose = require('mongoose');
 const asyncHandler = require('../utils/asyncHandler');
 const ScheduledContent = require('../model/scheduledContent');
 
+function parseCSVLine(line) {
+    const fields = [];
+    let current = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i];
+        if (char === '"') {
+            inQuotes = !inQuotes;
+        } else if (char === ',' && !inQuotes) {
+            fields.push(current.trim());
+            current = '';
+        } else {
+            current += char;
+        }
+    }
+    fields.push(current.trim());
+    return fields;
+}
+
 /**
  * @function scheduleContent
  * @description Creates a piece of content scheduled to auto-publish at a future UTC time.
@@ -88,4 +108,65 @@ const cancelScheduledContent = asyncHandler(async (req, res) => {
     return res.json({ success: true, content });
 });
 
-module.exports = { scheduleContent, listScheduledContent, cancelScheduledContent };
+const bulkScheduleContent = asyncHandler(async (req, res) => {
+    if (!req.file) {
+        return res.status(400).json({ success: false, message: 'CSV file is required' });
+    }
+
+    const content = req.file.buffer.toString('utf-8');
+    const lines = content.split(/\r?\n/).filter(line => line.trim());
+
+    if (lines.length < 2) {
+        return res.status(400).json({ success: false, message: 'CSV must have a header row and at least one data row' });
+    }
+
+    const header = parseCSVLine(lines[0]).map(h => h.toLowerCase());
+    const captionIdx = header.indexOf('caption');
+    const mediaUrlIdx = header.indexOf('mediaurl');
+    const scheduledAtIdx = header.indexOf('scheduledat');
+    const accountIdIdx = header.indexOf('accountid');
+    const platformIdx = header.indexOf('platform');
+
+    if (captionIdx === -1 || scheduledAtIdx === -1) {
+        return res.status(400).json({ success: false, message: 'CSV must contain "caption" and "scheduledAt" columns' });
+    }
+
+    const results = { created: 0, errors: [] };
+
+    for (let i = 1; i < lines.length; i++) {
+        const fields = parseCSVLine(lines[i]);
+        const caption = fields[captionIdx];
+        const scheduledAt = fields[scheduledAtIdx];
+
+        if (!caption || !scheduledAt) {
+            results.errors.push({ row: i + 1, reason: 'Missing caption or scheduledAt' });
+            continue;
+        }
+
+        const scheduledDate = new Date(scheduledAt);
+        if (Number.isNaN(scheduledDate.getTime()) || scheduledDate.getTime() <= Date.now()) {
+            results.errors.push({ row: i + 1, reason: 'Invalid or past scheduledAt date' });
+            continue;
+        }
+
+        try {
+            await ScheduledContent.create({
+                userId: req.user.id,
+                caption: caption.trim(),
+                mediaUrl: mediaUrlIdx !== -1 ? fields[mediaUrlIdx] : undefined,
+                timezone: 'UTC',
+                scheduledAt: scheduledDate,
+                accountId: accountIdIdx !== -1 && fields[accountIdIdx] ? fields[accountIdIdx] : undefined,
+                platform: platformIdx !== -1 && fields[platformIdx] ? fields[platformIdx] : undefined,
+                status: 'scheduled',
+            });
+            results.created++;
+        } catch (err) {
+            results.errors.push({ row: i + 1, reason: err.message });
+        }
+    }
+
+    return res.status(201).json({ success: true, ...results });
+});
+
+module.exports = { scheduleContent, listScheduledContent, cancelScheduledContent, bulkScheduleContent };

--- a/model/scheduledContent.js
+++ b/model/scheduledContent.js
@@ -37,6 +37,14 @@ const scheduledContentSchema = new mongoose.Schema(
             enum: ["scheduled", "published", "cancelled"],
             default: "scheduled",
         },
+        accountId: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "Creator",
+        },
+        platform: {
+            type: String,
+            enum: ["instagram", "youtube", "twitter", "tiktok"],
+        },
         publishedAt: {
             type: Date,
         },

--- a/routes/content.js
+++ b/routes/content.js
@@ -1,10 +1,14 @@
 const express = require('express');
 const router = express.Router();
+const multer = require('multer');
 const {
     scheduleContent,
     listScheduledContent,
     cancelScheduledContent,
+    bulkScheduleContent,
 } = require('../controller/contentController');
+
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 1024 * 1024 } });
 
 /**
  * @swagger
@@ -51,5 +55,7 @@ router.get('/scheduled', listScheduledContent);
  *         description: Not found
  */
 router.delete('/scheduled/:id', cancelScheduledContent);
+
+router.post('/schedule/bulk', upload.single('file'), bulkScheduleContent);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
Adds bulk content scheduling via CSV upload, allowing creators to schedule multiple posts in a single action.

## Changes
- `controller/contentController.js` — Added `bulkScheduleContent` handler and `parseCSVLine` CSV parser
- `routes/content.js` — Added `POST /api/content/schedule/bulk` endpoint with multer file upload (1MB limit, memory storage)
- `model/scheduledContent.js` — Added `accountId` and `platform` fields to the schema
- CSV must contain `caption` and `scheduledAt` columns; supports optional `mediaUrl`, `accountId`, and `platform`
- Returns created count and per-row error details on failure

Closes #710