### PR TITLE
fix: use req.user.id instead of req.user._id in instagram routes

### DIFF
--- a/routes/instagram.js
+++ b/routes/instagram.js
@@ -30,17 +30,17 @@ const asyncHandler = require('../utils/asyncHandler');
 
 
 router.get('/triggers', protect, asyncHandler(async (req, res) => {
-    const triggers = await DmTrigger.find({ creatorId: req.user._id });
+    const triggers = await DmTrigger.find({ creatorId: req.user.id });
     res.json({ success: true, data: triggers });
 }));
 
 router.post('/triggers', protect, asyncHandler(async (req, res) => {
-    const trigger = await DmTrigger.create({ ...req.body, creatorId: req.user._id });
+    const trigger = await DmTrigger.create({ ...req.body, creatorId: req.user.id });
     res.status(201).json({ success: true, data: trigger });
 }));
 
 router.delete('/triggers/:id', protect, asyncHandler(async (req, res) => {
-    const trigger = await DmTrigger.findOneAndDelete({ _id: req.params.id, creatorId: req.user._id });
+    const trigger = await DmTrigger.findOneAndDelete({ _id: req.params.id, creatorId: req.user.id });
     if (!trigger) return res.status(404).json({ success: false, message: 'Trigger not found' });
     res.json({ success: true, message: 'Trigger deleted' });
 }));


### PR DESCRIPTION
## Description

Instagram routes reference `req.user._id` but the JWT payload
(created by `serializeUser` in `auth.js`) stores the user ID as
`id: user._id.toString()`. This causes `req.user._id` to be
`undefined` in all Instagram DM trigger routes.

## Changes

- Replace all `req.user._id` references with `req.user.id` in
  `routes/instagram.js`

Closes #835