### PR TITLE
fix: strip client-supplied user_id/userId from DM trigger creation

### DIFF
--- a/routes/instagram.js
+++ b/routes/instagram.js
@@ -35,7 +35,8 @@ router.get('/triggers', protect, asyncHandler(async (req, res) => {
 }));
 
 router.post('/triggers', protect, asyncHandler(async (req, res) => {
-    const trigger = await DmTrigger.create({ ...req.body, creatorId: req.user._id });
+    const { user_id, userId, ...safeBody } = req.body;
+    const trigger = await DmTrigger.create({ ...safeBody, creatorId: req.user.id });
     res.status(201).json({ success: true, data: trigger });
 }));
 


### PR DESCRIPTION
## Description

The DM trigger creation endpoint spreads `req.body` directly into
`DmTrigger.create()`, which can let a client inject `user_id` or
`userId` fields. The backend should strip these fields and always
use the authenticated user's ID from the JWT.

## Changes

- Destructure `user_id` and `userId` out of `req.body` to prevent
  client-side injection of user identity fields
- Use `req.user.id` (JWT-authenticated) for `creatorId`

Closes #836