### PR TITLE
fix: handle stale/non-existent session tokens in auth middleware

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -43,12 +43,16 @@ const protect = async (req, res, next) => {
                 });
             }
         } else {
-            // For regular users, check if email is verified
             const User = require("../model/user");
             const user = await User.findOne({ email: decoded.email });
 
             if (!user) {
-                return res.redirect("/login");
+                if (wantsHtml(req)) return res.redirect("/login");
+                return res.status(401).json({
+                    success: false,
+                    message: "User not found",
+                    error: "User not found",
+                });
             }
 
             // Check if password was changed after token was issued
@@ -100,7 +104,7 @@ const protect = async (req, res, next) => {
  * @returns {Promise<void>|void}
  */
 const requireAdmin = (req, res, next) => {
-    if (req.user.role !== "admin") {
+    if (!req.user || req.user.role !== "admin") {
         return res.status(403).json({
             success: false,
             message: "Admin access required",
@@ -120,7 +124,7 @@ const requireAdmin = (req, res, next) => {
  * @returns {Promise<void>|void}
  */
 const preventContributorWrites = (req, res, next) => {
-    if (req.user.role === "contributor" || req.user.role === "guest_contributor") {
+    if (!req.user || req.user.role === "contributor" || req.user.role === "guest_contributor") {
         return res.status(403).json({
             success: false,
             message: "Contributor accounts do not have permission to modify data.",


### PR DESCRIPTION
## Description

The `protect` middleware at line 51 calls `res.redirect("/login")`
without checking `wantsHtml(req)`, causing API requests to receive
an HTML redirect instead of a JSON 401 when the user is not found.
Additionally, `requireAdmin` and `preventContributorWrites` will crash
if `req.user` is `undefined`.

## Changes

- Fix `protect` to check `wantsHtml(req)` before HTML redirect when
  user not found in database
- Return proper JSON 401 for API requests
- Add `!req.user` null check in `requireAdmin`
- Add `!req.user` null check in `preventContributorWrites`

Closes #838