### PR TITLE
test: add regression guard for route file load errors (#489)

### DIFF
--- a/test/routes-load.test.js
+++ b/test/routes-load.test.js
@@ -1,0 +1,44 @@
+// Regression guard for issue #489: a duplicate `const protect = require(...)`
+// declaration in routes/instagram.js previously caused a hard parse-time
+// crash (`SyntaxError: Identifier 'protect' has already been declared`)
+// that took down the entire server, since index.js requires this file at
+// module load time. That specific duplicate isn't present in this file as
+// of this commit, but nothing prevented it from being reintroduced silently
+// in a future edit — a syntax error in a route file is invisible until the
+// server actually restarts in production.
+//
+// This test requires every file in routes/ and just asserts it doesn't
+// throw. It won't catch runtime logic bugs, but it WILL catch:
+//   - duplicate top-level const/let declarations
+//   - other syntax errors
+//   - missing/renamed imports that break at require-time
+//
+// If this test ever fails, do NOT silence it — it means a route file
+// cannot be loaded and would crash the real server the same way #489 did.
+
+const fs = require("fs");
+const path = require("path");
+
+const ROUTES_DIR = path.join(__dirname, "..", "routes");
+
+describe("route files load without error", () => {
+  const routeFiles = fs
+    .readdirSync(ROUTES_DIR)
+    .filter((f) => f.endsWith(".js"));
+
+  test("routes directory is not empty (sanity check for this test itself)", () => {
+    expect(routeFiles.length).toBeGreaterThan(0);
+  });
+
+  routeFiles.forEach((file) => {
+    test(`routes/${file} requires without throwing`, () => {
+      const fullPath = path.join(ROUTES_DIR, file);
+      expect(() => {
+        // Clear the cache so re-running tests / watch mode re-evaluates
+        // the file fresh each time, rather than reusing a cached module.
+        delete require.cache[require.resolve(fullPath)];
+        require(fullPath);
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## 📝 Description
`routes/instagram.js` does not currently contain the duplicate `protect` declaration described in #489 — it declares `protect` exactly once via destructured import (`const { protect } = require('../middleware/auth');`). Verified via `npx jest routes-load --verbose` (16/16 passed, including `routes/instagram.js`). This suggests the issue was already fixed, or was reported against a different branch/commit.

Rather than leave this unaddressed, this PR adds a lightweight regression test that requires every file in `routes/` and asserts it loads without throwing. This directly covers the failure mode described in #489 (a hard parse-time crash from duplicate `const` declarations) and will catch it immediately in CI if ever reintroduced, in this file or any other route file.

## 🔗 Related Issues
Related to #489

## 📋 Type of Change
- [x] 🧪 Test update
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement

## 🔄 Changes Made
- Added `test/routes-load.test.js`: iterates every `.js` file in `routes/`, `require()`s it, and asserts it does not throw
- Catches the exact class of failure from #489 (duplicate top-level `const`/`let`, other syntax errors, broken imports at require-time) without depending on the specific line numbers or variable names from the original report

## ✅ Testing
### How to Test
1. `npx jest routes-load --verbose`
2. Confirm all route files pass, including `routes/instagram.js`
3. To confirm the test actually catches the bug class it targets: temporarily add a duplicate `const protect = require('../middleware/auth');` to `routes/instagram.js`, rerun the command above, and confirm `routes/instagram.js requires without throwing` fails with a `SyntaxError`. Revert the change afterward.

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
N/A — test-only change.

PASS test/routes-load.test.js (5.608 s)
route files load without error
√ routes directory is not empty (sanity check for this test itself) (4 ms)
√ routes/ai.js requires without throwing (1255 ms)
√ routes/analytics.js requires without throwing (96 ms)
√ routes/auth.js requires without throwing (180 ms)
√ routes/billing.js requires without throwing (22 ms)
√ routes/collaboration.js requires without throwing (34 ms)
√ routes/content.js requires without throwing (22 ms)
√ routes/domain.js requires without throwing (8 ms)
√ routes/inbox.js requires without throwing (16 ms)
√ routes/instagram.js requires without throwing (353 ms)
√ routes/qrCode.js requires without throwing (464 ms)
√ routes/settings.js requires without throwing (9 ms)
√ routes/smartNotificationRoutes.js requires without throwing (35 ms)
√ routes/sponsor.js requires without throwing (17 ms)
√ routes/suggestionRoutes.js requires without throwing (27 ms)
√ routes/url.js requires without throwing (25 ms)
Test Suites: 1 passed, 1 total
Tests: 16 passed, 16 total

## 🚀 Deployment Notes
None. Test-only addition, no runtime code touched, no new dependencies.

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings *(console warnings observed during the run are pre-existing informational logs from `controller/ai.js` and `services/dmQueueService.js` about missing `OPENAI_API_KEY`/`REDIS_URI` env vars in the test environment — unrelated to this change)*
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes *(this test file: 16/16 passed; note several pre-existing, unrelated test suites in this repo are currently failing due to `MongoMemoryServer.create()` timeouts in `jest.setup.js` — not caused by or related to this PR)*
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
This does not close #489 outright, since the specific reported bug (duplicate `const protect` on line 30) isn't reproducible on current `main`. Recommend the issue reporter (`ionfwsrijan`) confirm which branch/commit they saw the duplicate on before closing #489 entirely — this PR is a preventive safety net regardless of that outcome.

Also flagging: while verifying this, `npm test` (full suite) showed 14 failing test suites / 88 failing tests, all due to `MongoMemoryServer.create()` timing out in the shared `jest.setup.js` `beforeAll` hook — appears to be a pre-existing CI/environment issue (likely the MongoDB binary download being slow or blocked) unrelated to this change. Worth a separate issue if not already tracked.

---
