### PR TITLE
fix(csrf): exempt Instagram webhook endpoint from CSRF verification

### DIFF
--- a/middleware/csrf.js
+++ b/middleware/csrf.js
@@ -49,6 +49,12 @@ function generateCsrf(req, res, next) {
     next();
 }
 
+// Paths that receive external webhook callbacks and cannot include CSRF tokens.
+// These endpoints must rely on their own verification (e.g. HMAC signatures) instead.
+const CSRF_EXEMPT_PATHS = new Set([
+    '/api/instagram/webhook',
+]);
+
 /**
  * Middleware to verify the CSRF token on state-changing requests (POST, PUT, DELETE, PATCH).
  * Validates that the request includes a valid CSRF token matching the one in the secure cookie.
@@ -59,6 +65,12 @@ function verifyCsrf(req, res, next) {
 
     // Skip verification for safe HTTP methods
     if (safeMethods.includes(req.method)) {
+        return next();
+    }
+
+    // Skip verification for exempt external webhook endpoints, which are
+    // authenticated separately (e.g. via HMAC signature verification)
+    if (CSRF_EXEMPT_PATHS.has(req.path)) {
         return next();
     }
 

--- a/tests/middleware/csrf.test.js
+++ b/tests/middleware/csrf.test.js
@@ -1,0 +1,86 @@
+const { verifyCsrf } = require("../../middleware/csrf");
+
+function createResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+    redirect: jest.fn(),
+    accepts: jest.fn(),
+  };
+}
+
+describe("verifyCsrf", () => {
+  it("allows safe methods without a CSRF token", () => {
+    const req = { method: "GET", path: "/api/urls", cookies: {}, headers: {}, originalUrl: "/api/urls" };
+    const res = createResponse();
+    const next = jest.fn();
+
+    verifyCsrf(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("blocks a POST to a non-exempt path with a missing or mismatched token", () => {
+    const req = {
+      method: "POST",
+      path: "/bio/save",
+      cookies: { _csrf: "abc123" },
+      headers: {},
+      body: {},
+      originalUrl: "/bio/save",
+      accepts: jest.fn().mockReturnValue(true),
+    };
+    const res = createResponse();
+    res.accepts = req.accepts;
+    const next = jest.fn();
+
+    verifyCsrf(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Invalid CSRF token. Request blocked.",
+      error: "CSRF token mismatch",
+    });
+  });
+
+  it("allows a POST to the Instagram webhook path without a CSRF token", () => {
+    const req = {
+      method: "POST",
+      path: "/api/instagram/webhook",
+      cookies: {},
+      headers: {},
+      body: {},
+      originalUrl: "/api/instagram/webhook",
+    };
+    const res = createResponse();
+    const next = jest.fn();
+
+    verifyCsrf(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("still requires a valid CSRF token on other POST routes even if their prefix overlaps the exempt path", () => {
+    const req = {
+      method: "POST",
+      path: "/api/instagram/other-action",
+      cookies: { _csrf: "abc123" },
+      headers: {},
+      body: {},
+      originalUrl: "/api/instagram/other-action",
+      accepts: jest.fn().mockReturnValue(true),
+    };
+    const res = createResponse();
+    res.accepts = req.accepts;
+    const next = jest.fn();
+
+    verifyCsrf(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});


### PR DESCRIPTION
## 📝 Description
Instagram's webhook POST callbacks cannot include a CSRF token, so the global `verifyCsrf` middleware was rejecting every delivery with a 403, making the Instagram DM automation feature non-functional.

Added a `CSRF_EXEMPT_PATHS` allowlist in `middleware/csrf.js` and skip verification only for `/api/instagram/webhook`. The endpoint remains protected by its existing HMAC signature verification (`verifyWebhookSignature`), so no security regression is introduced.

## 🔗 Related Issues
Fixes #488

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔄 Changes Made
- Added `CSRF_EXEMPT_PATHS` allowlist in `middleware/csrf.js`
- `verifyCsrf` now skips CSRF token validation for paths in the exempt list, before the token check runs
- Added `tests/middleware/csrf.test.js` with regression tests

## ✅ Testing
### How to Test
1. Send a `POST` to `/api/instagram/webhook` without a `_csrf` token or `x-csrf-token` header — it should no longer return 403
2. Send a `POST` to any other route (e.g. `/bio/save`) without a valid token — it should still return 403 as before
3. Run `npx jest tests/middleware/csrf.test.js`

### Test Coverage
- [x] Unit tests added/updated

Covers: safe methods bypass, non-exempt POSTs still blocked, the webhook path is exempt, and paths merely sharing a prefix with the webhook path are not accidentally exempt.

## 🚀 Deployment Notes
None — no config or env changes required.

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Full test suite: 148/149 passing. The 1 failure (`tests/controllers/sponsor.test.js`) is a pre-existing, unrelated issue — confirmed present on clean `upstream/main` before this change. `npm run build` passes clean.