### PR TITLE
fix: increase bcrypt saltRounds from 10 to 12

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -218,7 +218,7 @@ const signup = asyncHandler(async (req, res, next) => {
         return res.status(409).json({ success: false, message: "User already exists" });
     }
 
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const hashedPassword = await bcrypt.hash(password, 12);
     const verificationToken = generateVerificationToken();
     const verificationTokenExpiry = getVerificationTokenExpiry();
 
@@ -765,7 +765,7 @@ const resetPassword = asyncHandler(async (req, res) => {
     }
 
     try {
-        const hashedPassword = await bcrypt.hash(newPassword, 10);
+        const hashedPassword = await bcrypt.hash(newPassword, 12);
         user.password = hashedPassword;
         user.passwordChangedAt = new Date();
         await user.save();

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -188,7 +188,7 @@ router.put('/security/password', preventContributorWrites, asyncHandler(async (r
         return res.status(400).json({ error: 'New password must be at least 8 characters.' });
     }
 
-    const salt = await bcrypt.genSalt(10);
+    const salt = await bcrypt.genSalt(12);
     user.password = await bcrypt.hash(newPassword, salt);
     user.passwordChangedAt = new Date();
     await user.save();


### PR DESCRIPTION
## Summary

Increases bcrypt password hashing difficulty from rounds 10 to 12 across all password operations.

**Fixes #782** - Stronger password hashing improves resistance to offline brute-force attacks in case of database breach. Increases computation time from ~10ms to ~50ms per attempt, making cracking attempts significantly more expensive.

## Changes

- `controller/auth.js`: signup password hashing (line 221)
- `controller/auth.js`: password reset hashing (line 768) 
- `routes/settings.js`: password change hashing (line 191)

## Security Impact

- ✅ Addresses OWASP: Weak Cryptography
- ✅ Mitigates offline password cracking risk
- ✅ Maintains backward compatibility (existing hashes still validate)

## Testing

Code syntax validated locally. Pre-existing test suite has unrelated syntax error in smartNotificationService.js.