### PR TITLE
fix(collaboration): Detect expired tokens when rendering invite acceptance pages

### DIFF
--- a/controller/collaborationController.js
+++ b/controller/collaborationController.js
@@ -174,6 +174,17 @@ const acceptInvite = asyncHandler(async (req, res, next) => {
     });
   }
 
+  if (invite.status === 'expired' || (invite.expiresAt && invite.expiresAt < new Date())) {
+    if (invite.status !== 'expired') {
+      await Invite.updateOne({ _id: invite._id }, { $set: { status: 'expired' } });
+      invite.status = 'expired';
+    }
+    return res.render('invite-accept', {
+      status: 'expired',
+      invite,
+    });
+  }
+
   // Don't auto-accept anymore if unauthenticated.
   // Just render the pending state so they can copy the token and login.
   res.render('invite-accept', {

--- a/index.js
+++ b/index.js
@@ -1041,5 +1041,3 @@ if (require.main === module) {
 }
 
 module.exports = app;
-
-.catch(err => console.error("Promise.all failed:", err));


### PR DESCRIPTION
Resolves #779. Immediately returns 'expired' status and updates the database if an invite is accessed post-expiration.