### PR TITLE
fix(security): Prevent duplicate invitation flooding and unbounded email spam in collaboration controller

### DIFF
--- a/controller/collaborationController.js
+++ b/controller/collaborationController.js
@@ -66,7 +66,6 @@ const sendCollaboratorInvite = asyncHandler(async (req, res, next) => {
   const existingPendingInvite = await Invite.findOne({
     inviter: req.user.id,
     email: normalizedEmail,
-    projectName: normalizedProjectName,
     status: 'pending',
   });
 

--- a/index.js
+++ b/index.js
@@ -1041,5 +1041,3 @@ if (require.main === module) {
 }
 
 module.exports = app;
-
-.catch(err => console.error("Promise.all failed:", err));


### PR DESCRIPTION
Resolves #778. Enforces a strict 1-active-invite-per-email policy for each inviter to prevent spam.