### PR TITLE
refactor(deps): Eradicate deprecated shortid package dependency in favor of modern nanoid link generator

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -1,5 +1,4 @@
 const { nanoid } = require('nanoid');
-const shortid = require('shortid');
 const QRCode = require('qrcode');
 const mongoose = require('mongoose');
 const Url = require('../model/url');
@@ -107,7 +106,7 @@ async function handleGenerateShortURL(req, res) {
     const { redirectUrl: redirectUrlField, url, title, customSlug, tag } = req.body;
     const redirectUrl = redirectUrlField || url;
 
-    let shortId = shortid();
+    let shortId = nanoid(8);
     if (customSlug) {
         const slug = String(customSlug).trim().toLowerCase();
         const existing = await Url.findOne({ shortId: slug });

--- a/index.js
+++ b/index.js
@@ -142,7 +142,6 @@ const { protect, preventContributorWrites, redirectIfAuthenticated } = require("
 
 const fs = require('fs');
 app.use(express.static(path.join(__dirname, 'public')));
-const shortid = require('shortid');
 const multer = require('multer');
 const services = require('./services.config');
 const User = require('./model/user');

--- a/index.js
+++ b/index.js
@@ -1040,5 +1040,3 @@ if (require.main === module) {
 }
 
 module.exports = app;
-
-.catch(err => console.error("Promise.all failed:", err));

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "qrcode-svg": "^1.1.0",
         "rate-limit-mongo": "^2.3.2",
         "sharp": "^0.35.3",
-        "shortid": "^2.2.17",
         "swagger-jsdoc": "^6.3.0",
         "swagger-ui-express": "^5.0.1",
         "zod": "^3.25.0"
@@ -8505,13 +8504,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shortid": {
-      "version": "2.2.17",
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.8"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "qrcode-svg": "^1.1.0",
     "rate-limit-mongo": "^2.3.2",
     "sharp": "^0.35.3",
-    "shortid": "^2.2.17",
     "swagger-jsdoc": "^6.3.0",
     "swagger-ui-express": "^5.0.1",
     "zod": "^3.25.0"


### PR DESCRIPTION
Resolves #773. Completely replaces shortid usage with nanoid and uninstalls shortid.