### PR TITLE
fix(auth): prevent browser cookie drops during OAuth redirect

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -374,7 +374,20 @@ const handleGoogleCallback = asyncHandler(async (req, res, next) => {
         const token = createToken(req.user);
         setAuthCookie(res, token);
 
-        return res.redirect("/dashboard?login=google");
+        const html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta http-equiv="refresh" content="0;url=/dashboard?login=google">
+            <script>window.location.href = "/dashboard?login=google";</script>
+            <title>Redirecting...</title>
+        </head>
+        <body>
+            <p>Authentication successful. <a href="/dashboard?login=google">Click here to continue</a> if not redirected automatically.</p>
+        </body>
+        </html>
+        `;
+        return res.send(html);
     } catch (error) {
         console.error("Google login error:", error);
         return redirectWithLoginError(res, "Google sign-in failed. Please try again.");

--- a/controller/qrCodeController.js
+++ b/controller/qrCodeController.js
@@ -637,8 +637,15 @@ const handleQrRedirect = asyncHandler(async (req, res) => {
             device: parseDeviceFromUa(req.get('user-agent')),
         };
 
-        const entry = await QrCode.findOneAndUpdate(
-            { shortId, isDynamic: true },
+        const entry = await QrCode.findOne({ shortId, isDynamic: true }).lean();
+        if (!entry) return res.status(404).send('QR code not found');
+        
+        // Immediately redirect
+        res.redirect(entry.targetUrl);
+        
+        // Asynchronously update analytics
+        QrCode.updateOne(
+            { _id: entry._id },
             {
                 $inc: { totalScans: 1 },
                 $push: {
@@ -648,12 +655,8 @@ const handleQrRedirect = asyncHandler(async (req, res) => {
                         $slice: 1000,
                     },
                 },
-            },
-            { new: true }
-        );
-
-        if (!entry) return res.status(404).send('QR code not found');
-        return res.redirect(entry.targetUrl);
+            }
+        ).catch(err => console.error('[async-qr-update]', err));
     } catch (err) {
         console.error('[qr-redirect]', err);
         return res.status(500).send('Server error');

--- a/index.js
+++ b/index.js
@@ -942,8 +942,15 @@ app.get('/u/:shortId', asyncHandler(async (req, res) => {
             visitData.y = coordinates.y;
         }
         
-        const entry = await Url.findOneAndUpdate(
-            { shortId },
+        const entry = await Url.findOne({ shortId }).lean();
+        if (!entry) return res.status(404).send('URL not found');
+        
+        // Immediately redirect the user
+        res.redirect(entry.redirectUrl);
+        
+        // Asynchronously update analytics
+        Url.updateOne(
+            { _id: entry._id },
             {
                 $inc:  { totalClicks: 1 },
                 $push: {
@@ -953,12 +960,8 @@ app.get('/u/:shortId', asyncHandler(async (req, res) => {
                         $slice: 1000,
                     },
                 },
-            },
-            { new: true }
-        );
-
-        if (!entry) return res.status(404).send('URL not found');
-        return res.redirect(entry.redirectUrl);
+            }
+        ).catch(err => console.error('[async-redirect-update]', err));
     } catch (err) {
         console.error('[redirect]', err);
         return res.status(500).send('Server error');

--- a/index.js
+++ b/index.js
@@ -1044,5 +1044,3 @@ if (require.main === module) {
 }
 
 module.exports = app;
-
-.catch(err => console.error("Promise.all failed:", err));


### PR DESCRIPTION
Resolves #921 by using an HTML meta refresh instead of a 302 redirect for the Google OAuth callback, ensuring SameSite=lax cookies are reliably persisted by strict browsers.