### PR TITLE
fix(settings): restore motionEffects negation in scroll behavior

### DIFF
--- a/public/js/pages/settings.js
+++ b/public/js/pages/settings.js
@@ -178,7 +178,7 @@
             const id = anchor.getAttribute('href').slice(1);
             const el = document.getElementById(id);
             if (el) {
-                el.scrollIntoView({ behavior: userData.preferences?.motionEffects ! ? 'auto' : 'smooth' });
+                el.scrollIntoView({ behavior: !userData.preferences?.motionEffects ? 'auto' : 'smooth' });
                 subNavItems.forEach((a) => a.classList.remove('active'));
                 anchor.classList.add('active');
             }

--- a/tests/settingsMotionScroll.test.js
+++ b/tests/settingsMotionScroll.test.js
@@ -1,0 +1,37 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function getScrollBehavior(motionEffectsEnabled) {
+  return !motionEffectsEnabled ? 'auto' : 'smooth';
+}
+
+describe('settings.js motionEffects scroll behavior', () => {
+  const settingsPath = path.join(__dirname, '..', 'public', 'js', 'pages', 'settings.js');
+
+  it('parses without syntax errors', () => {
+    const result = spawnSync(process.execPath, ['--check', settingsPath], {
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+  });
+
+  it('uses instant scroll when motion effects are off', () => {
+    expect(getScrollBehavior(false)).toBe('auto');
+    expect(getScrollBehavior(undefined)).toBe('auto');
+    expect(getScrollBehavior(null)).toBe('auto');
+  });
+
+  it('uses smooth scroll when motion effects are on', () => {
+    expect(getScrollBehavior(true)).toBe('smooth');
+  });
+
+  it('wires reduced-motion preference into scrollIntoView', () => {
+    const source = fs.readFileSync(settingsPath, 'utf8');
+    expect(source).toContain(
+      "!userData.preferences?.motionEffects ? 'auto' : 'smooth'"
+    );
+  });
+});


### PR DESCRIPTION
## Description
`public/js/pages/settings.js` had invalid syntax (`motionEffects ! ?`) which threw `SyntaxError: Unexpected token '!'` and blocked the settings page script from loading. Restored the intended negation so sub-nav scroll respects the motionEffects preference.

## Related Issues
Fixes #969

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Style changes
- [ ] Performance improvement
- [x] Test update

## Changes Made
- Fixed `scrollIntoView` behavior ternary to `!userData.preferences?.motionEffects ? 'auto' : 'smooth'`
- Added regression test covering parse success, reduced-motion mapping, and the wired expression

## Testing

### How to Test
1. `node --check public/js/pages/settings.js`
2. `npx jest tests/settingsMotionScroll.test.js --verbose`
3. Open settings, toggle Motion Effects off, click a sub-nav item — scroll should be instant (`auto`)

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Screenshots (if applicable)
N/A

## Deployment Notes
None

## Breaking Changes
- None

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## Additional Context
Pre-existing failures in `sponsor.test.js`, `bioProfileValidation.test.js`, and `billingWebhookMount.test.js` are unrelated to this change.

Made with [Cursor](https://cursor.com)