### PR TITLE
fix(auth): allow empty body on guest contributor login

### DIFF
--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -14,6 +14,9 @@ const loginSchema = z.object({
   remember: z.union([z.boolean(), z.string(), z.number()]).optional(),
 });
 
+// Guest contributor login creates a session without creator credentials.
+const contributorLoginSchema = z.object({}).passthrough();
+
 const resendVerificationSchema = z.object({
   email: z.string().trim().toLowerCase().email('Invalid email format'),
 });
@@ -91,6 +94,7 @@ function validate(schema, source = 'body', viewName, buildLocals = () => ({})) {
 module.exports = { 
     signupSchema, 
     loginSchema, 
+    contributorLoginSchema,
     resendVerificationSchema,
     collaborationInviteSchema,
     collaborationAcceptSchema,
@@ -105,6 +109,7 @@ module.exports = {
     loginValidator: validate(loginSchema, 'body', 'login', () => ({
         googleAuthConfigured: Boolean(process.env.GOOGLE_CLIENT_ID)
     })),
+    contributorLoginValidator: validate(contributorLoginSchema, 'body'),
     resendVerificationValidator: validate(resendVerificationSchema, 'body', 'resend-verification'),
     shortenUrlValidator: validate(urlShortenSchema, 'body'),
     updateQrColorsValidator: validate(urlQRColorsSchema, 'body'),

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,7 +2,7 @@ const express = require("express");
 const passport = require("passport");
 const GoogleStrategy = require("passport-google-oauth20").Strategy;
 const { signup, login, handleGoogleCallback, loginAsContributor, verifyEmail, resendVerificationEmail, requestPasswordReset, resetPassword } = require("../controller/auth");
-const { signupValidator, loginValidator, resendVerificationValidator } = require("../middleware/validators");
+const { signupValidator, loginValidator, contributorLoginValidator, resendVerificationValidator } = require("../middleware/validators");
 const connectDB = require("../connect");
 const { loginLimiter, signupLimiter, emailVerificationLimiter, forgotPasswordLimiter, resetPasswordLimiter } = require("../middleware/rateLimiters");
 const { redirectIfAuthenticated } = require("../middleware/auth");
@@ -177,7 +177,7 @@ router.post("/login", loginLimiter, loginValidator, login);
  *       500:
  *         description: Internal server error
  */
-router.post("/login/contributor", loginLimiter, loginValidator, loginAsContributor);
+router.post("/login/contributor", loginLimiter, contributorLoginValidator, loginAsContributor);
 
 /**
  * @swagger
@@ -195,7 +195,7 @@ router.post("/login/contributor", loginLimiter, loginValidator, loginAsContribut
  *       500:
  *         description: Internal server error
  */
-router.post("/api/auth/contributor-login", loginLimiter, loginValidator, loginAsContributor);
+router.post("/api/auth/contributor-login", loginLimiter, contributorLoginValidator, loginAsContributor);
 
 
 /**

--- a/tests/routes/contributorLoginValidator.test.js
+++ b/tests/routes/contributorLoginValidator.test.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('passport', () => ({
+    use: jest.fn(),
+    authenticate: jest.fn(() => (req, res, next) => next()),
+}));
+
+jest.mock('../../controller/auth', () => ({
+    signup: jest.fn(),
+    login: jest.fn(),
+    handleGoogleCallback: jest.fn(),
+    loginAsContributor: jest.fn((req, res) => res.status(200).json({ success: true })),
+    verifyEmail: jest.fn(),
+    resendVerificationEmail: jest.fn(),
+    requestPasswordReset: jest.fn(),
+    resetPassword: jest.fn(),
+}));
+
+jest.mock('../../middleware/rateLimiters', () => ({
+    loginLimiter: (req, res, next) => next(),
+    signupLimiter: (req, res, next) => next(),
+    emailVerificationLimiter: (req, res, next) => next(),
+    forgotPasswordLimiter: (req, res, next) => next(),
+    resetPasswordLimiter: (req, res, next) => next(),
+}));
+
+jest.mock('../../connect', () => jest.fn());
+jest.mock('../../model/passwordResetToken', () => ({
+    findOne: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../model/user', () => ({
+    findOne: jest.fn().mockResolvedValue(null),
+}));
+
+describe('contributor login routes', () => {
+    let app;
+
+    beforeEach(() => {
+        jest.resetModules();
+        app = express();
+        app.use(express.json());
+        app.set('view engine', 'ejs');
+        app.response.render = function render(view, locals) {
+            return this.status(200).json({ view, locals });
+        };
+        app.use(require('../../routes/auth'));
+    });
+
+    test.each(['/login/contributor', '/api/auth/contributor-login'])(
+        'allows %s without creator credentials',
+        async (path) => {
+            const res = await request(app).post(path).send({});
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toEqual({ success: true });
+        }
+    );
+});


### PR DESCRIPTION
## 📝 Description
Guest contributor login creates a session without creator credentials, but both endpoints were wired through `loginValidator`, which required `email` and `password`. Requests with an empty body were rejected with 400 even though the controller ignores those fields.

## 🔗 Related Issues
Fixes #664

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 🔄 Changes Made
- Added `contributorLoginSchema` / `contributorLoginValidator` that accepts an empty (or passthrough) body
- Switched `POST /login/contributor` and `POST /api/auth/contributor-login` to the new validator
- Added a route test covering empty-body guest login

## ✅ Testing

### How to Test
1. `POST /login/contributor` with `{}` (no email/password)
2. `POST /api/auth/contributor-login` with `{}`
3. Confirm both create a guest session instead of returning 400 validation errors

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
N/A

## 🚀 Deployment Notes
None

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
`loginAsContributor` does not read email/password; only creator login should keep the strict credential schema.

---

**Thank you for contributing to CreatorOS!** 🙌