### PR TITLE
fix(utils): coerce nullish identifiers in Redis key helpers

### DIFF
--- a/tests/utils/nullishIdentifierKeys.test.js
+++ b/tests/utils/nullishIdentifierKeys.test.js
@@ -1,0 +1,31 @@
+const {
+    getLoginAttemptKey,
+    getResetAttemptKey,
+} = require('../../utils/loginAttemptManager');
+const { getProfileCacheKey } = require('../../utils/profileCache');
+
+describe('nullish identifier key helpers', () => {
+    test.each([
+        [undefined, 'login_attempts:'],
+        [null, 'login_attempts:'],
+        ['User@Example.com', 'login_attempts:user@example.com'],
+    ])('getLoginAttemptKey(%p)', (input, expected) => {
+        expect(getLoginAttemptKey(input)).toBe(expected);
+    });
+
+    test.each([
+        [undefined, 'reset_attempts:'],
+        [null, 'reset_attempts:'],
+        ['User@Example.com', 'reset_attempts:user@example.com'],
+    ])('getResetAttemptKey(%p)', (input, expected) => {
+        expect(getResetAttemptKey(input)).toBe(expected);
+    });
+
+    test.each([
+        [undefined, 'profile:'],
+        [null, 'profile:'],
+        ['CreatorName', 'profile:creatorname'],
+    ])('getProfileCacheKey(%p)', (input, expected) => {
+        expect(getProfileCacheKey(input)).toBe(expected);
+    });
+});

--- a/utils/loginAttemptManager.js
+++ b/utils/loginAttemptManager.js
@@ -8,11 +8,11 @@ const RESET_LOCKOUT_DURATION = 60 * 60; // 1 hour in seconds
 const redisClient = createRedisClient();
 
 function getLoginAttemptKey(identifier) {
-    return `login_attempts:${identifier.toLowerCase()}`;
+    return `login_attempts:${(identifier || '').toString().toLowerCase()}`;
 }
 
 function getResetAttemptKey(identifier) {
-    return `reset_attempts:${identifier.toLowerCase()}`;
+    return `reset_attempts:${(identifier || '').toString().toLowerCase()}`;
 }
 
 async function getFailedLoginAttempts(identifier) {
@@ -149,6 +149,8 @@ async function clearResetAttempts(identifier) {
 }
 
 module.exports = {
+    getLoginAttemptKey,
+    getResetAttemptKey,
     checkIfLoginLocked,
     recordFailedLoginAttempt,
     clearLoginAttempts,

--- a/utils/profileCache.js
+++ b/utils/profileCache.js
@@ -5,7 +5,7 @@ const PROFILE_TTL = 5 * 60; // 5 minutes in seconds
 const redisClient = createRedisClient();
 
 function getProfileCacheKey(identifier) {
-    return `profile:${identifier.toLowerCase()}`;
+    return `profile:${(identifier || '').toString().toLowerCase()}`;
 }
 
 async function getProfileFromCache(identifier) {
@@ -54,6 +54,7 @@ async function invalidateProfileCache(identifier) {
 }
 
 module.exports = {
+    getProfileCacheKey,
     getProfileFromCache,
     setProfileInCache,
     invalidateProfileCache,


### PR DESCRIPTION
## 📝 Description
Key helpers in `loginAttemptManager` and `profileCache` called `identifier.toLowerCase()` directly. Nullish identifiers threw `TypeError` instead of producing a safe fallback key.

## 🔗 Related Issues
Fixes #544

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 🔄 Changes Made
- Sanitize identifiers with `(identifier || '').toString().toLowerCase()` in attempt and profile cache key generators
- Export the key helpers and add unit coverage for nullish inputs

## ✅ Testing

### How to Test
1. Call `getLoginAttemptKey(undefined)` / `getProfileCacheKey(null)`
2. Confirm no TypeError and keys use an empty-string fallback

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
N/A

## 🚀 Deployment Notes
None

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Matches the proposed fix in #544.

---

**Thank you for contributing to CreatorOS!** 🙌