### PR TITLE
feat(security): require password and TOTP to toggle 2FA

### DIFF
--- a/model/user.js
+++ b/model/user.js
@@ -62,6 +62,13 @@ const userSchema = new mongoose.Schema(
             type: Boolean,
             default: false,
         },
+
+        // Base32-encoded TOTP secret used when two-factor authentication is enabled.
+        twoFactorSecret: {
+            type: String,
+            default: null,
+            select: false,
+        },
         
         preferences: {
             appearanceMode: { type: String, enum: ['light', 'dark', 'system'], default: 'light' },

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -13,6 +13,7 @@ const EngagementHistory = require('../model/engagementHistory');
 const { preventContributorWrites } = require('../middleware/auth');
 const { validate, updateProfileSchema } = require('../middleware/validators');
 const { isEmailTransportConfigured, sendDeletionConfirmationEmail } = require('../utils/email');
+const { verifyTotp } = require('../utils/totp');
 
 const asyncHandler = fn => (req, res, next) =>
     Promise.resolve(fn(req, res, next)).catch(next);
@@ -128,14 +129,54 @@ router.get('/billing', asyncHandler(async (req, res) => {
  *         description: Internal server error
  */
 router.put('/security/2fa', preventContributorWrites, asyncHandler(async (req, res) => {
-    const { enabled } = req.body;
-    
-    const user = await User.findById(req.user.id);
+    const { enabled, password, otp, secret } = req.body;
+    const enableTwoFactor = !!enabled;
+
+    const user = await User.findById(req.user.id).select('+twoFactorSecret +password');
     if (!user) return res.status(404).json({ error: 'User not found' });
-    
-    user.twoFactorEnabled = !!enabled;
+
+    // Local accounts must re-verify their current password before 2FA changes.
+    if (user.authProvider === 'local') {
+        if (!password) {
+            return res.status(401).json({ error: 'Password is required to update 2FA settings' });
+        }
+
+        const isMatch = await bcrypt.compare(password, user.password);
+        if (!isMatch) {
+            return res.status(401).json({ error: 'Incorrect password' });
+        }
+    }
+
+    if (enableTwoFactor) {
+        const sharedSecret = secret || user.twoFactorSecret;
+        if (!sharedSecret) {
+            return res.status(400).json({
+                error: 'A TOTP secret is required to enable two-factor authentication',
+            });
+        }
+
+        if (!otp || !verifyTotp(sharedSecret, otp)) {
+            return res.status(401).json({ error: 'Invalid or missing authenticator code' });
+        }
+
+        user.twoFactorSecret = sharedSecret;
+        user.twoFactorEnabled = true;
+    } else {
+        // Disabling an active 2FA configuration still requires a valid OTP challenge.
+        if (user.twoFactorEnabled) {
+            if (!user.twoFactorSecret) {
+                return res.status(400).json({ error: 'Two-factor authentication is misconfigured' });
+            }
+            if (!otp || !verifyTotp(user.twoFactorSecret, otp)) {
+                return res.status(401).json({ error: 'Invalid or missing authenticator code' });
+            }
+        }
+
+        user.twoFactorEnabled = false;
+    }
+
     await user.save();
-    
+
     res.json({ message: '2FA settings updated successfully', twoFactorEnabled: user.twoFactorEnabled });
 }));
 

--- a/tests/utils/totp.test.js
+++ b/tests/utils/totp.test.js
@@ -1,0 +1,20 @@
+const { verifyTotp, generateHotp, decodeBase32 } = require('../../utils/totp');
+
+describe('totp helpers', () => {
+    // RFC 6238 appendix B style secret ("12345678901234567890" as base32).
+    const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+    test('verifyTotp accepts the current window code', () => {
+        const now = 1_111_111_111_000;
+        const counter = Math.floor(now / 1000 / 30);
+        const token = generateHotp(decodeBase32(secret), counter);
+
+        expect(verifyTotp(secret, token, { now, window: 0 })).toBe(true);
+    });
+
+    test('verifyTotp rejects invalid tokens', () => {
+        expect(verifyTotp(secret, '000000', { now: Date.now(), window: 0 })).toBe(false);
+        expect(verifyTotp(secret, 'abc', { now: Date.now() })).toBe(false);
+        expect(verifyTotp('', '123456')).toBe(false);
+    });
+});

--- a/utils/totp.js
+++ b/utils/totp.js
@@ -1,0 +1,75 @@
+const crypto = require('crypto');
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+function decodeBase32(secret) {
+    const cleaned = String(secret || '')
+        .toUpperCase()
+        .replace(/=+$/g, '')
+        .replace(/[^A-Z2-7]/g, '');
+
+    let bits = '';
+    for (const char of cleaned) {
+        const value = BASE32_ALPHABET.indexOf(char);
+        if (value < 0) continue;
+        bits += value.toString(2).padStart(5, '0');
+    }
+
+    const bytes = [];
+    for (let i = 0; i + 8 <= bits.length; i += 8) {
+        bytes.push(parseInt(bits.slice(i, i + 8), 2));
+    }
+    return Buffer.from(bytes);
+}
+
+function generateHotp(secretBuffer, counter) {
+    const counterBuffer = Buffer.alloc(8);
+    counterBuffer.writeBigUInt64BE(BigInt(counter));
+
+    const hmac = crypto.createHmac('sha1', secretBuffer).update(counterBuffer).digest();
+    const offset = hmac[hmac.length - 1] & 0xf;
+    const code =
+        ((hmac[offset] & 0x7f) << 24) |
+        ((hmac[offset + 1] & 0xff) << 16) |
+        ((hmac[offset + 2] & 0xff) << 8) |
+        (hmac[offset + 3] & 0xff);
+
+    return String(code % 10 ** 6).padStart(6, '0');
+}
+
+/**
+ * Verify a TOTP token against a base32-encoded shared secret.
+ * @param {string} secret - Base32 TOTP secret
+ * @param {string|number} token - User-provided OTP
+ * @param {{ window?: number, step?: number, now?: number }} [options]
+ * @returns {boolean}
+ */
+function verifyTotp(secret, token, options = {}) {
+    const window = options.window ?? 1;
+    const step = options.step ?? 30;
+    const now = options.now ?? Date.now();
+    const expected = String(token || '').replace(/\s+/g, '');
+
+    if (!/^\d{6}$/.test(expected)) {
+        return false;
+    }
+
+    const secretBuffer = decodeBase32(secret);
+    if (!secretBuffer.length) {
+        return false;
+    }
+
+    const counter = Math.floor(now / 1000 / step);
+    for (let offset = -window; offset <= window; offset += 1) {
+        if (generateHotp(secretBuffer, counter + offset) === expected) {
+            return true;
+        }
+    }
+    return false;
+}
+
+module.exports = {
+    verifyTotp,
+    generateHotp,
+    decodeBase32,
+};


### PR DESCRIPTION
## 📝 Description
Updating 2FA settings previously only required an authenticated session. Compromised sessions could enable or disable two-factor authentication without proving knowledge of the account password or possession of an authenticator.

## 🔗 Related Issues
Fixes #766

## 📋 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 🔄 Changes Made
- Require current password (`bcrypt.compare`) for local accounts before 2FA changes; return 401 when missing/invalid
- Require a valid TOTP code before enabling 2FA and before disabling an active 2FA configuration
- Persist optional `twoFactorSecret` on the user model and add a small RFC 6238 TOTP helper
- Add unit coverage for TOTP verification

## ✅ Testing

### How to Test
1. Authenticate as a local user
2. `PUT /api/settings/security/2fa` with `{ enabled: true }` and no password/otp → 401
3. Retry with valid `password`, `otp`, and `secret` (or stored secret) → 200 and `twoFactorEnabled: true`
4. Disable with valid password + otp → 200 and `twoFactorEnabled: false`

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
N/A

## 🚀 Deployment Notes
Clients that toggle 2FA must send `password` (local auth) and `otp`. Enabling without a stored secret must also include `secret`.

## ⚠️ Breaking Changes
- The 2FA settings endpoint now rejects requests that omit password/OTP verification fields.

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Google-authenticated accounts skip password verification (no local password) but still require a valid OTP challenge when enabling/disabling 2FA.

---

**Thank you for contributing to CreatorOS!** 🙌