### PR TITLE
fix(infra): isolate BullMQ queue and worker Redis connections

### DIFF
--- a/services/dmQueueService.js
+++ b/services/dmQueueService.js
@@ -25,8 +25,7 @@ function createFallbackQueue() {
 let dmQueue = createFallbackQueue();
 let dmWorker = null;
 
-// Initialize BullMQ worker and queue if a standard Redis URI is provided.
-if (REDIS_URI) {
+function createRedisConnection(label) {
     const connection = new IORedis(REDIS_URI, {
         maxRetriesPerRequest: null,
         connectTimeout: 5000,
@@ -35,16 +34,27 @@ if (REDIS_URI) {
 
     // Add listeners for Redis connection events to improve observability.
     connection.on('error', (err) => {
-        console.error('❌ Redis Connection Error:', err.message);
+        console.error(`❌ Redis Connection Error (${label}):`, err.message);
     });
 
+    return connection;
+}
+
+// Initialize BullMQ worker and queue if a standard Redis URI is provided.
+// Queue and Worker must use separate sockets: workers issue blocking commands
+// (BRPOP/BLPOP) that starve shared connections used for queue.add().
+if (REDIS_URI) {
+    const queueConnection = createRedisConnection('dm-queue');
+
     // Create the Queue only when Redis is explicitly configured.
-    dmQueue = new Queue('dm-automation-queue', { connection });
+    dmQueue = new Queue('dm-automation-queue', { connection: queueConnection });
 
     // Create the Worker only when Redis is available and not on Vercel.
     if (process.env.VERCEL === '1') {
         console.warn("📦 DM Worker disabled on Vercel to prevent hanging Redis connections. Use Vercel Cron/Webhooks instead.");
     } else {
+        const workerConnection = createRedisConnection('dm-worker');
+
         dmWorker = new Worker('dm-automation-queue', async (job) => {
         const { senderId, message, triggerKeyword } = job.data;
         
@@ -64,7 +74,7 @@ if (REDIS_URI) {
             throw error;
         }
     }, {
-        connection,
+        connection: workerConnection,
         // Add rate limit pacing (e.g., max 50 jobs per 10 seconds)
         limiter: {
             max: 50,

--- a/tests/services/bullmqSeparateConnections.test.js
+++ b/tests/services/bullmqSeparateConnections.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('BullMQ Redis connection isolation', () => {
+    test('dmQueueService creates distinct queue and worker connections', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../../services/dmQueueService.js'),
+            'utf8'
+        );
+
+        expect(source).toContain('createRedisConnection');
+        expect(source).toContain("createRedisConnection('dm-queue')");
+        expect(source).toContain("createRedisConnection('dm-worker')");
+        expect(source).toMatch(/new Queue\([\s\S]*connection:\s*queueConnection/);
+        expect(source).toMatch(/new Worker\([\s\S]*connection:\s*workerConnection/);
+    });
+
+    test('analyticsRefreshWorker creates distinct queue and worker connections', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../../workers/analyticsRefreshWorker.js'),
+            'utf8'
+        );
+
+        expect(source).toContain('const queueConnection = new IORedis');
+        expect(source).toContain('const workerConnection = new IORedis');
+        expect(source).toMatch(/new Queue\([\s\S]*connection:\s*queueConnection/);
+        expect(source).toMatch(/new Worker\([\s\S]*connection:\s*workerConnection/);
+        expect(source).not.toMatch(/new Queue\([\s\S]*connection:\s*redisConnection/);
+    });
+});

--- a/workers/analyticsRefreshWorker.js
+++ b/workers/analyticsRefreshWorker.js
@@ -27,13 +27,19 @@ if (!REDIS_URI) {
 } else if (process.env.VERCEL === '1') {
     console.warn("📦 Analytics refresh worker disabled on Vercel to prevent hanging Redis connections. Use Vercel Cron instead.");
 } else {
-    const redisConnection = new IORedis(REDIS_URI, {
+    // BullMQ workers use blocking Redis commands; share nothing with the Queue client.
+    const queueConnection = new IORedis(REDIS_URI, {
+        maxRetriesPerRequest: null,
+        connectTimeout: 5000,
+        lazyConnect: true,
+    });
+    const workerConnection = new IORedis(REDIS_URI, {
         maxRetriesPerRequest: null,
         connectTimeout: 5000,
         lazyConnect: true,
     });
 
-    analyticsQueue = new Queue("analytics-refresh", { connection: redisConnection });
+    analyticsQueue = new Queue("analytics-refresh", { connection: queueConnection });
 
     analyticsWorker = new Worker("analytics-refresh", async (job) => {
         const { creatorId } = job.data;
@@ -81,7 +87,7 @@ if (!REDIS_URI) {
 
         console.log(`[AnalyticsWorker] Refreshed creator: ${creator.username}`);
     }, {
-        connection: redisConnection,
+        connection: workerConnection,
         concurrency: 5,
     });
 


### PR DESCRIPTION
## 📝 Description
BullMQ `Queue` and `Worker` instances shared a single `IORedis` socket. Workers issue blocking Redis commands, which can stall `queue.add()` and surface command timeouts under load.

## 🔗 Related Issues
Fixes #772

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 🔄 Changes Made
- Create dedicated Redis connections for the DM automation queue and worker
- Create dedicated Redis connections for the analytics refresh queue and worker
- Add a source-level regression test asserting connection isolation

## ✅ Testing

### How to Test
1. Configure `REDIS_URI` / `REDIS_URL` outside Vercel
2. Enqueue DM/analytics jobs while workers are polling
3. Confirm `queue.add()` succeeds without Redis command timeouts from shared blocking sockets

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
N/A

## 🚀 Deployment Notes
Each queue/worker pair now opens two Redis connections instead of one.

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Matches BullMQ guidance to avoid sharing connections between producers and blocking workers.

---

**Thank you for contributing to CreatorOS!** 🙌