### PR TITLE
fix(middleware): generate CSP nonce before Helmet

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const helmet = require("helmet");
 const cors = require("cors");
 const passport = require("passport");
 const path = require("path");
+const crypto = require("crypto");
 const rateLimit = require("express-rate-limit");
 const cacheHeadersMiddleware = require("./middleware/cacheHeaders");
 const {
@@ -78,9 +79,33 @@ const smartNotificationRoutes = require("./routes/smartNotificationRoutes");
 
 const { generateCsrf, verifyCsrf } = require("./middleware/csrf");
 
+// Generate a per-request nonce before Helmet so early exits (CSRF/validation)
+// still receive CSP headers that reference res.locals.nonce.
+app.use((req, res, next) => {
+  res.locals.nonce = crypto.randomBytes(16).toString("base64");
+  next();
+});
+
 app.use(
   helmet({
-    contentSecurityPolicy: false, // Disabling CSP by default so we don't break existing inline scripts/styles without testing
+    contentSecurityPolicy: {
+      useDefaults: false,
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: [
+          "'self'",
+          (req, res) => `'nonce-${res.locals.nonce}'`,
+          "https://cdn.jsdelivr.net",
+        ],
+        styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+        fontSrc: ["'self'", "https://fonts.gstatic.com"],
+        imgSrc: ["'self'", "data:", "https:"],
+        connectSrc: ["'self'", "https:"],
+        frameAncestors: ["'none'"],
+        objectSrc: ["'none'"],
+        frameSrc: ["'none'"],
+      },
+    },
     crossOriginEmbedderPolicy: false,
   }),
 );
@@ -128,22 +153,6 @@ app.set("view engine", "ejs");
 app.set("views", path.join(__dirname, "view"));
 app.locals.BRAND = BRAND;
 
-// Generate a per-request nonce for inline scripts (used by CSP below and
-// exposed to views via res.locals.nonce)
-const crypto = require("crypto");
-app.use((req, res, next) => {
-  res.locals.nonce = crypto.randomBytes(16).toString("base64");
-  next();
-});
-
-// Content Security Policy (CSP) header - defense-in-depth against XSS
-app.use((req, res, next) => {
-  res.setHeader(
-    "Content-Security-Policy",
-    `default-src 'self'; script-src 'self' 'nonce-${res.locals.nonce}' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https:; frame-ancestors 'none'; object-src 'none'; frame-src 'none';`,
-  );
-  next();
-});
 const uploadLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 10,

--- a/tests/cspNonceHelmet.test.js
+++ b/tests/cspNonceHelmet.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('CSP nonce Helmet ordering', () => {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+
+    test('generates nonce before Helmet and uses Helmet CSP directives', () => {
+        const nonceIdx = source.indexOf('res.locals.nonce = crypto.randomBytes');
+        const helmetIdx = source.indexOf('helmet({');
+        const cspFalseIdx = source.indexOf('contentSecurityPolicy: false');
+        const manualCspIdx = source.indexOf("res.setHeader(\n    \"Content-Security-Policy\"");
+
+        expect(nonceIdx).toBeGreaterThan(-1);
+        expect(helmetIdx).toBeGreaterThan(-1);
+        expect(nonceIdx).toBeLessThan(helmetIdx);
+        expect(cspFalseIdx).toBe(-1);
+        expect(manualCspIdx).toBe(-1);
+        expect(source).toContain("(req, res) => `'nonce-${res.locals.nonce}'`");
+    });
+});


### PR DESCRIPTION
## 📝 Description
CSP was disabled in Helmet and applied manually later in the middleware stack. Requests that failed early (for example CSRF rejection) never received Content-Security-Policy headers.

## 🔗 Related Issues
Fixes #769

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 🔄 Changes Made
- Generate `res.locals.nonce` immediately before Helmet initialization
- Enable Helmet's native CSP directives using the per-request nonce
- Remove the late-stage manual `Content-Security-Policy` header middleware
- Add a source-order regression test

## ✅ Testing

### How to Test
1. Start the app and inspect response headers on a normal page load
2. Confirm `Content-Security-Policy` includes `script-src ... 'nonce-...'`
3. Trigger an early validation/CSRF failure and confirm CSP is still present

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
N/A

## 🚀 Deployment Notes
None

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Preserves the previous CSP allowlist (jsDelivr scripts, Google Fonts, etc.) while using Helmet's CSP pipeline.

---

**Thank you for contributing to CreatorOS!** 🙌