### PR TITLE
fix(suggestions): surface provider failures instead of fake success

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,13 @@ APP_URL=
 BASE_URL=
 
 # OpenAI API Key (For AI content suggestions)
-# If missing, AI features will gracefully return 503 errors.
+# If missing, AI features return an unavailable error unless template mode is enabled.
 OPENAI_API_KEY=
+
+# Explicit offline template mode for /suggestions.
+# When true, missing/failing AI provider returns labelled template captions/hashtags (no invented songs).
+# When false/unset, provider failures surface a retryable unavailable state instead of fake success.
+SUGGESTIONS_TEMPLATE_MODE=false
 
 # Redis Connection String (For BullMQ and Caching)
 # If missing, background workers and queues may be disabled gracefully.

--- a/controller/suggestionController.js
+++ b/controller/suggestionController.js
@@ -1,102 +1,295 @@
 const services = require('../services.config');
 const asyncHandler = require('../utils/asyncHandler');
+const { wantsHtml } = require('../utils/requestType');
+const { suggestionSchema } = require('../middleware/validators');
+
+const OPENAI_TIMEOUT_MS = 20000;
+const TEMPLATE_MODE_FLAG = 'SUGGESTIONS_TEMPLATE_MODE';
 
 /**
- * @function generateAISuggestions
- * @description Generates AI-powered content suggestions for the user.
- * @param {Object} req - Express request object
- * @param {Object} res - Express response object
- * @param {Function} next - Express next middleware function
- * @returns {Promise<void>|void}
+ * Typed error for AI suggestion provider failures.
  */
-async function generateAISuggestions(topic) {
-  // If OpenAI API key is configured, use it for real AI generation
-  if (process.env.OPENAI_API_KEY) {
-    try {
-      const response = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
-        },
-        body: JSON.stringify({
-          model: 'gpt-3.5-turbo',
-          messages: [
-            {
-              role: 'system',
-              content: 'You are an expert social media manager. Generate exactly 5 captions, 9 hashtags, and 5 song recommendations (with title and mood) for the given topic. Return ONLY a raw JSON object with keys: "captions" (array of strings), "hashtags" (array of strings), "songs" (array of objects with "title" and "mood").'
-            },
-            {
-              role: 'user',
-              content: `Topic: ${topic}`
-            }
-          ]
-        })
-      });
-      const data = await response.json();
-      if (data.choices && data.choices[0]) {
-        try {
-          let rawContent = data.choices[0].message.content;
-          rawContent = rawContent.replace(/^```json\s*/i, '').replace(/\s*```$/i, '').trim();
-          return JSON.parse(rawContent);
-        } catch (parseError) {
-          console.error('JSON Parse Failed, falling back to mock generator:', parseError);
-        }
-      }
-    } catch (e) {
-      console.error('AI Generation Failed, falling back to mock generator:', e);
-    }
+class SuggestionProviderError extends Error {
+  constructor(message, { code, statusCode = 503, retryable = true } = {}) {
+    super(message);
+    this.name = 'SuggestionProviderError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.retryable = retryable;
   }
+}
 
-  // Fallback: Dynamic mock generator based on the topic
-  const words = topic.split(' ').filter(w => w.length > 2);
+function isTemplateModeEnabled() {
+  return String(process.env[TEMPLATE_MODE_FLAG] || '').toLowerCase() === 'true';
+}
+
+/**
+ * Offline template captions/hashtags. Never invents song titles.
+ * @param {string} topic
+ * @returns {{ captions: string[], hashtags: string[], songs: [], source: 'template' }}
+ */
+function generateTemplateSuggestions(topic) {
+  const words = topic.split(' ').filter((w) => w.length > 2);
   const mainWord = words.length > 0 ? words[0].toLowerCase() : 'vibes';
   const capWord = mainWord.charAt(0).toUpperCase() + mainWord.slice(1);
 
   return {
     captions: [
-      `Embracing the ${mainWord} today ✨`,
-      `Nothing beats good ${mainWord} and great company 🥂`,
-      `${capWord} state of mind 🧠`,
-      `Living for these ${mainWord} moments 🌟`,
-      `Just another day enjoying the ${mainWord} 📸`
+      `Embracing the ${mainWord} today`,
+      `Nothing beats good ${mainWord} and great company`,
+      `${capWord} state of mind`,
+      `Living for these ${mainWord} moments`,
+      `Just another day enjoying the ${mainWord}`
     ],
     hashtags: [
       `#${mainWord}`, `#${mainWord}vibes`, `#${mainWord}life`,
       `#instadaily`, `#explore`, `#trending`,
       `#${mainWord}goals`, `#foryou`, `#creator`
     ],
-    songs: [
-      { title: `${capWord} Dreams - The Creator`, mood: 'chill' },
-      { title: `Summer ${capWord} - DJ Mix`, mood: 'upbeat' },
-      { title: `Midnight ${capWord} - Lofi Boy`, mood: 'focus' },
-      { title: `Golden ${capWord} - Sunset Bros`, mood: 'cinematic' },
-      { title: `Pure ${capWord} - Acoustic`, mood: 'relaxing' }
-    ]
+    songs: [],
+    source: 'template'
+  };
+}
+
+function normalizeProviderPayload(parsed) {
+  if (!parsed || typeof parsed !== 'object') {
+    throw new SuggestionProviderError('AI returned an invalid response. Please try again.', {
+      code: 'INVALID_RESPONSE'
+    });
+  }
+
+  const captions = Array.isArray(parsed.captions) ? parsed.captions.filter((c) => typeof c === 'string') : [];
+  const hashtags = Array.isArray(parsed.hashtags) ? parsed.hashtags.filter((h) => typeof h === 'string') : [];
+  const songs = Array.isArray(parsed.songs)
+    ? parsed.songs.filter((s) => s && typeof s.title === 'string')
+    : [];
+
+  if (captions.length === 0 || hashtags.length === 0) {
+    throw new SuggestionProviderError('AI returned an incomplete response. Please try again.', {
+      code: 'INVALID_RESPONSE'
+    });
+  }
+
+  return {
+    captions,
+    hashtags,
+    songs,
+    source: 'openai'
+  };
+}
+
+/**
+ * @function generateAISuggestions
+ * @description Generates AI-powered content suggestions, or labelled templates when explicitly enabled.
+ * @param {string} topic
+ * @returns {Promise<{captions: string[], hashtags: string[], songs: Array, source: string}>}
+ */
+async function generateAISuggestions(topic) {
+  if (!process.env.OPENAI_API_KEY) {
+    if (isTemplateModeEnabled()) {
+      return generateTemplateSuggestions(topic);
+    }
+    throw new SuggestionProviderError(
+      'AI suggestions are unavailable because no provider is configured. Set OPENAI_API_KEY or enable SUGGESTIONS_TEMPLATE_MODE.',
+      { code: 'NOT_CONFIGURED', retryable: false }
+    );
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), OPENAI_TIMEOUT_MS);
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are an expert social media manager. Generate exactly 5 captions, 9 hashtags, and 5 song recommendations (with title and mood) for the given topic. Return ONLY a raw JSON object with keys: "captions" (array of strings), "hashtags" (array of strings), "songs" (array of objects with "title" and "mood").'
+          },
+          {
+            role: 'user',
+            content: `Topic: ${topic}`
+          }
+        ]
+      })
+    });
+
+    if (!response.ok) {
+      throw new SuggestionProviderError(
+        'The AI provider is temporarily unavailable. Please try again.',
+        { code: 'PROVIDER_ERROR' }
+      );
+    }
+
+    const data = await response.json();
+    if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+      throw new SuggestionProviderError(
+        'AI returned an invalid response. Please try again.',
+        { code: 'INVALID_RESPONSE' }
+      );
+    }
+
+    let rawContent = data.choices[0].message.content || '';
+    rawContent = rawContent.replace(/^```json\s*/i, '').replace(/\s*```$/i, '').trim();
+
+    let parsed;
+    try {
+      parsed = JSON.parse(rawContent);
+    } catch (parseError) {
+      throw new SuggestionProviderError(
+        'AI returned unreadable content. Please try again.',
+        { code: 'INVALID_RESPONSE' }
+      );
+    }
+
+    return normalizeProviderPayload(parsed);
+  } catch (err) {
+    if (err instanceof SuggestionProviderError) {
+      if (isTemplateModeEnabled()) {
+        console.error('AI generation failed; serving labelled template mode:', err.message);
+        return generateTemplateSuggestions(topic);
+      }
+      throw err;
+    }
+
+    if (err && err.name === 'AbortError') {
+      const timeoutError = new SuggestionProviderError(
+        'AI suggestions timed out. Please try again.',
+        { code: 'TIMEOUT' }
+      );
+      if (isTemplateModeEnabled()) {
+        console.error('AI generation timed out; serving labelled template mode');
+        return generateTemplateSuggestions(topic);
+      }
+      throw timeoutError;
+    }
+
+    console.error('AI Generation Failed:', err);
+    const providerError = new SuggestionProviderError(
+      'AI suggestions are temporarily unavailable. Please try again.',
+      { code: 'PROVIDER_ERROR' }
+    );
+    if (isTemplateModeEnabled()) {
+      return generateTemplateSuggestions(topic);
+    }
+    throw providerError;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function renderSuggestionsPage(res, status, locals) {
+  return res.status(status).render('suggestions', {
+    categories: [],
+    services,
+    ...locals
+  });
+}
+
+function buildErrorLocals(topic, err) {
+  const isProviderError = err instanceof SuggestionProviderError;
+  return {
+    result: null,
+    selected: topic || null,
+    source: null,
+    error: isProviderError
+      ? err.message
+      : 'An unexpected error occurred while generating suggestions.',
+    errorCode: isProviderError ? err.code : 'UNEXPECTED',
+    retryable: isProviderError ? err.retryable : true
   };
 }
 
 exports.getPage = (req, res) => {
-  // We no longer need static categories
-  res.render('suggestions', { categories: [], result: null, selected: null, error: null, services });
+  renderSuggestionsPage(res, 200, {
+    result: null,
+    selected: null,
+    source: null,
+    error: null,
+    errorCode: null,
+    retryable: false
+  });
 };
 
-const { suggestionSchema } = require('../middleware/validators');
-
-exports.getSuggestions = asyncHandler(async (req, res, next) => {
+exports.getSuggestions = asyncHandler(async (req, res) => {
   const validationResult = suggestionSchema.safeParse(req.body);
   if (!validationResult.success) {
     const errorMsg = validationResult.error.errors[0]?.message || 'Invalid input provided.';
-    return res.render('suggestions', { categories: [], result: null, selected: null, error: errorMsg, services });
+    if (!wantsHtml(req)) {
+      return res.status(400).json({
+        success: false,
+        message: errorMsg,
+        error: errorMsg,
+        code: 'VALIDATION_ERROR',
+        retryable: false
+      });
+    }
+    return renderSuggestionsPage(res, 400, {
+      result: null,
+      selected: null,
+      source: null,
+      error: errorMsg,
+      errorCode: 'VALIDATION_ERROR',
+      retryable: false
+    });
   }
 
   const { topic } = validationResult.data;
 
   try {
     const result = await generateAISuggestions(topic);
-    res.render('suggestions', { categories: [], result, selected: topic, error: null, services });
+
+    if (!wantsHtml(req)) {
+      return res.json({
+        success: true,
+        source: result.source,
+        selected: topic,
+        result: {
+          captions: result.captions,
+          hashtags: result.hashtags,
+          songs: result.songs
+        },
+        isTemplate: result.source === 'template'
+      });
+    }
+
+    return renderSuggestionsPage(res, 200, {
+      result,
+      selected: topic,
+      source: result.source,
+      error: null,
+      errorCode: null,
+      retryable: false
+    });
   } catch (err) {
     console.error('Error generating suggestions:', err);
-    res.render('suggestions', { categories: [], result: null, selected: topic, error: 'An unexpected error occurred while generating suggestions.', services });
+    const locals = buildErrorLocals(topic, err);
+    const status = err instanceof SuggestionProviderError ? err.statusCode : 500;
+
+    if (!wantsHtml(req)) {
+      return res.status(status).json({
+        success: false,
+        message: locals.error,
+        error: locals.error,
+        code: locals.errorCode,
+        retryable: locals.retryable,
+        selected: topic
+      });
+    }
+
+    return renderSuggestionsPage(res, status, locals);
   }
 });
+
+exports.generateAISuggestions = generateAISuggestions;
+exports.generateTemplateSuggestions = generateTemplateSuggestions;
+exports.SuggestionProviderError = SuggestionProviderError;
+exports.TEMPLATE_MODE_FLAG = TEMPLATE_MODE_FLAG;

--- a/public/css/suggestions.css
+++ b/public/css/suggestions.css
@@ -318,6 +318,65 @@
 }
 .suggestions-page .toast.show { transform: translateX(-50%) translateY(0); opacity: 1; }
 
+/* Status / provenance banner */
+.suggestions-page .status-banner {
+  display: none;
+  margin: 0 1.5rem 0;
+  padding: 0.75rem 0.9rem;
+  border: 2px solid var(--border);
+  background: var(--surface);
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+.suggestions-page .status-banner.show { display: flex; }
+.suggestions-page .status-banner.error {
+  border-color: var(--danger);
+  background: rgba(225, 59, 59, 0.08);
+}
+.suggestions-page .status-banner.template {
+  border-color: var(--accent);
+  background: rgba(228, 193, 59, 0.12);
+}
+.suggestions-page .status-banner-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+.suggestions-page .status-banner-copy strong {
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.suggestions-page .status-banner-copy span {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+.suggestions-page .status-retry-btn {
+  flex-shrink: 0;
+  border: 2px solid var(--border);
+  background: var(--text);
+  color: #fff;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+}
+.suggestions-page .status-retry-btn:hover { transform: translate(-1px, -1px); box-shadow: var(--shadow-sm); }
+.suggestions-page .panel-empty {
+  padding: 0.85rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+.suggestions-page .unavailable-state .status-retry-btn {
+  margin-top: 0.75rem;
+}
+
 /* ── CUSTOM VARIABLES (page-specific) ── */
 .suggestions-page {
   --shadow-sm: 2px 2px 0px #111111;

--- a/tests/controllers/suggestionController.test.js
+++ b/tests/controllers/suggestionController.test.js
@@ -1,0 +1,245 @@
+const {
+  generateAISuggestions,
+  generateTemplateSuggestions,
+  SuggestionProviderError,
+  getSuggestions,
+  getPage,
+} = require('../../controller/suggestionController');
+
+describe('suggestionController AI provenance', () => {
+  const originalFetch = global.fetch;
+  let originalOpenAIKey;
+  let originalTemplateMode;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalOpenAIKey = process.env.OPENAI_API_KEY;
+    originalTemplateMode = process.env.SUGGESTIONS_TEMPLATE_MODE;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.SUGGESTIONS_TEMPLATE_MODE;
+  });
+
+  afterEach(() => {
+    if (originalOpenAIKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalOpenAIKey;
+    }
+    if (originalTemplateMode === undefined) {
+      delete process.env.SUGGESTIONS_TEMPLATE_MODE;
+    } else {
+      process.env.SUGGESTIONS_TEMPLATE_MODE = originalTemplateMode;
+    }
+    global.fetch = originalFetch;
+  });
+
+  function mockOpenAIResponse(content, { ok = true, status = 200 } = {}) {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok,
+      status,
+      statusText: ok ? 'OK' : 'Bad Gateway',
+      json: async () => ({
+        choices: [
+          {
+            message: { content },
+          },
+        ],
+      }),
+    });
+  }
+
+  function createResponse() {
+    return {
+      status: jest.fn().mockReturnThis(),
+      render: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  }
+
+  it('returns openai-sourced suggestions on a successful provider response', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    mockOpenAIResponse(JSON.stringify({
+      captions: ['Caption one', 'Caption two'],
+      hashtags: ['#one', '#two'],
+      songs: [{ title: 'Verified Track', mood: 'upbeat' }],
+    }));
+
+    const result = await generateAISuggestions('morning coffee');
+
+    expect(result.source).toBe('openai');
+    expect(result.captions).toEqual(['Caption one', 'Caption two']);
+    expect(result.hashtags).toEqual(['#one', '#two']);
+    expect(result.songs).toEqual([{ title: 'Verified Track', mood: 'upbeat' }]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws NOT_CONFIGURED when the API key is missing and template mode is off', async () => {
+    await expect(generateAISuggestions('travel vlog')).rejects.toMatchObject({
+      name: 'SuggestionProviderError',
+      code: 'NOT_CONFIGURED',
+      retryable: false,
+      statusCode: 503,
+    });
+  });
+
+  it('serves labelled template mode without songs when enabled and unconfigured', async () => {
+    process.env.SUGGESTIONS_TEMPLATE_MODE = 'true';
+
+    const result = await generateAISuggestions('summer festival');
+
+    expect(result.source).toBe('template');
+    expect(result.captions.length).toBeGreaterThan(0);
+    expect(result.hashtags.length).toBeGreaterThan(0);
+    expect(result.songs).toEqual([]);
+    expect(result.captions.join(' ')).not.toMatch(/DJ Mix/);
+  });
+
+  it('throws PROVIDER_ERROR on non-OK provider responses when template mode is off', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    mockOpenAIResponse('{}', { ok: false, status: 502 });
+
+    await expect(generateAISuggestions('desk setup')).rejects.toMatchObject({
+      code: 'PROVIDER_ERROR',
+      retryable: true,
+    });
+  });
+
+  it('throws INVALID_RESPONSE on unparseable provider JSON when template mode is off', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    mockOpenAIResponse('not-json-at-all');
+
+    await expect(generateAISuggestions('desk setup')).rejects.toMatchObject({
+      code: 'INVALID_RESPONSE',
+    });
+  });
+
+  it('throws TIMEOUT when the provider aborts and template mode is off', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    global.fetch = jest.fn().mockImplementation(() => {
+      const err = new Error('Aborted');
+      err.name = 'AbortError';
+      return Promise.reject(err);
+    });
+
+    await expect(generateAISuggestions('desk setup')).rejects.toMatchObject({
+      code: 'TIMEOUT',
+    });
+  });
+
+  it('falls back to labelled templates on provider failure when template mode is on', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    process.env.SUGGESTIONS_TEMPLATE_MODE = 'true';
+    mockOpenAIResponse('not-json-at-all');
+
+    const result = await generateAISuggestions('creator tips');
+
+    expect(result.source).toBe('template');
+    expect(result.songs).toEqual([]);
+  });
+
+  it('generateTemplateSuggestions never invents song titles', () => {
+    const result = generateTemplateSuggestions('beach sunset');
+    expect(result.source).toBe('template');
+    expect(result.songs).toEqual([]);
+  });
+
+  it('getSuggestions returns JSON unavailable state for missing configuration', async () => {
+    const req = {
+      body: { topic: 'growth tips' },
+      get: () => 'application/json',
+      xhr: false,
+      accepts: () => false,
+    };
+    const res = createResponse();
+
+    await getSuggestions(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: false,
+      code: 'NOT_CONFIGURED',
+      retryable: false,
+    }));
+    expect(res.render).not.toHaveBeenCalled();
+  });
+
+  it('getSuggestions renders HTML with template provenance when enabled', async () => {
+    process.env.SUGGESTIONS_TEMPLATE_MODE = 'true';
+    const req = {
+      body: { topic: 'growth tips' },
+      get: () => 'text/html',
+      xhr: false,
+      accepts: () => 'html',
+    };
+    const res = createResponse();
+
+    await getSuggestions(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.render).toHaveBeenCalledWith(
+      'suggestions',
+      expect.objectContaining({
+        source: 'template',
+        error: null,
+        result: expect.objectContaining({
+          source: 'template',
+          songs: [],
+        }),
+      })
+    );
+  });
+
+  it('getSuggestions returns successful JSON with openai provenance', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    mockOpenAIResponse(JSON.stringify({
+      captions: ['A'],
+      hashtags: ['#a'],
+      songs: [{ title: 'Song', mood: 'chill' }],
+    }));
+
+    const req = {
+      body: { topic: 'growth tips' },
+      get: () => 'application/json',
+      xhr: false,
+      accepts: () => false,
+    };
+    const res = createResponse();
+
+    await getSuggestions(req, res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      source: 'openai',
+      isTemplate: false,
+      result: expect.objectContaining({
+        captions: ['A'],
+        hashtags: ['#a'],
+        songs: [{ title: 'Song', mood: 'chill' }],
+      }),
+    }));
+  });
+
+  it('getPage renders a clean empty suggestions page', () => {
+    const req = {};
+    const res = createResponse();
+
+    getPage(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.render).toHaveBeenCalledWith(
+      'suggestions',
+      expect.objectContaining({
+        result: null,
+        error: null,
+        source: null,
+      })
+    );
+  });
+
+  it('SuggestionProviderError exposes actionable metadata', () => {
+    const err = new SuggestionProviderError('boom', { code: 'PROVIDER_ERROR' });
+    expect(err.retryable).toBe(true);
+    expect(err.statusCode).toBe(503);
+    expect(err.code).toBe('PROVIDER_ERROR');
+  });
+});

--- a/view/suggestions.ejs
+++ b/view/suggestions.ejs
@@ -7,7 +7,7 @@
     `
 }) %>
 
-<div class="suggestions-page">
+<div class="suggestions-page" data-csrf="<%= typeof csrfToken !== 'undefined' ? csrfToken : '' %>">
 <!-- page content begins -->
   <div class="main-content">
 
@@ -23,6 +23,14 @@
       <h1 class="page-title">Caption & Hashtag Generator</h1>
     </div>
 
+    <div id="statusBanner" class="status-banner<%= (typeof error !== 'undefined' && error) ? ' show error' : (typeof source !== 'undefined' && source === 'template' ? ' show template' : '') %>" role="status" aria-live="polite"<%= (typeof error !== 'undefined' && error) || (typeof source !== 'undefined' && source === 'template') ? '' : ' hidden' %>>
+      <div class="status-banner-copy">
+        <strong id="statusBannerTitle"><%= (typeof error !== 'undefined' && error) ? 'Suggestions unavailable' : (typeof source !== 'undefined' && source === 'template' ? 'Template mode' : '') %></strong>
+        <span id="statusBannerMessage"><%= (typeof error !== 'undefined' && error) ? error : (typeof source !== 'undefined' && source === 'template' ? 'These captions and hashtags are offline templates, not AI-generated results. Music recommendations are omitted.' : '') %></span>
+      </div>
+      <button type="button" class="status-retry-btn" id="statusRetryBtn"<%= (typeof retryable !== 'undefined' && retryable) ? '' : ' hidden' %>>Retry</button>
+    </div>
+
     <!-- Three columns -->
     <div class="tool-grid">
 
@@ -35,7 +43,7 @@
           <div>
             <div class="field-label">Topic / Concept</div>
             <textarea class="field-textarea" id="topicInput"
-              placeholder="e.g. My morning desk setup and creative routine..."></textarea>
+              placeholder="e.g. My morning desk setup and creative routine..."><%= typeof selected !== 'undefined' && selected ? selected : '' %></textarea>
           </div>
 
           <!-- Platform -->
@@ -73,7 +81,7 @@
         <!-- Generate -->
         <button type="button" class="generate-btn" id="generateBtn" onclick="generateCaptions()">
           <div class="spinner"></div>
-          <span class="btn-text">✦ Generate Captions</span>
+          <span class="btn-text">Generate Captions</span>
         </button>
 
         <!-- Usage -->
@@ -103,7 +111,6 @@
           </div>
         </div>
 
-        <!-- Captions will be injected here -->
         <div class="captions-list" id="captionsList">
           <div class="empty-state" id="emptyState">
             <div class="empty-icon">
@@ -117,87 +124,25 @@
 
       <!-- ── COL 3: RIGHT PANEL ── -->
       <div class="col-right">
-
-        <!-- Trending Hashtags -->
         <div class="right-panel">
-          <div class="right-panel-head">02. Trending Hashtags</div>
+          <div class="right-panel-head">02. Hashtags</div>
           <div class="hashtag-list" id="hashtagList">
-            <div class="hashtag-row" onclick="copyHashtag('#CREATORECONOMY')">
-              <span class="hashtag-name">#CREATORECONOMY</span>
-              <div class="hashtag-score-wrap">
-                <span class="hashtag-score">98/100</span>
-                <div class="hashtag-bar-bg"><div class="hashtag-bar" style="width:98%"></div></div>
-              </div>
-            </div>
-            <div class="hashtag-row" onclick="copyHashtag('#AIGENERATED')">
-              <span class="hashtag-name">#AIGENERATED</span>
-              <div class="hashtag-score-wrap">
-                <span class="hashtag-score">85/100</span>
-                <div class="hashtag-bar-bg"><div class="hashtag-bar" style="width:85%"></div></div>
-              </div>
-            </div>
-            <div class="hashtag-row" onclick="copyHashtag('#PRODUCTIVITYHACKS')">
-              <span class="hashtag-name">#PRODUCTIVITYHACKS</span>
-              <div class="hashtag-score-wrap">
-                <span class="hashtag-score">72/100</span>
-                <div class="hashtag-bar-bg"><div class="hashtag-bar" style="width:72%"></div></div>
-              </div>
-            </div>
-            <div class="hashtag-row" onclick="copyHashtag('#DESKSETUP')">
-              <span class="hashtag-name">#DESKSETUP</span>
-              <div class="hashtag-score-wrap">
-                <span class="hashtag-score">64/100</span>
-                <div class="hashtag-bar-bg"><div class="hashtag-bar" style="width:64%"></div></div>
-              </div>
-            </div>
+            <div class="panel-empty" id="hashtagEmpty">Generate suggestions to see hashtags for your topic.</div>
           </div>
-          <button type="button" class="see-more-btn" onclick="showToast('Loading more trends...')">See more trends</button>
         </div>
 
-        <!-- Recommended Audio -->
         <div class="right-panel">
           <div class="right-panel-head">03. Recommended Audio</div>
-          <div class="audio-list">
-            <div class="audio-row">
-              <div class="audio-play">
-                <svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3" fill="#fff"/></svg>
-              </div>
-              <div class="audio-info">
-                <div class="audio-name">Lofi M...</div>
-                <div class="audio-sub">High Growth Track</div>
-              </div>
-              <button type="button" class="audio-add" onclick="showToast('Added to project!')">+</button>
-            </div>
-            <div class="audio-row">
-              <div class="audio-play">
-                <svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3" fill="#fff"/></svg>
-              </div>
-              <div class="audio-info">
-                <div class="audio-name">Tech R...</div>
-                <div class="audio-sub">Trending Globally</div>
-              </div>
-              <button type="button" class="audio-add" onclick="showToast('Added to project!')">+</button>
-            </div>
-            <div class="audio-row">
-              <div class="audio-play teal">
-                <svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3" fill="#111"/></svg>
-              </div>
-              <div class="audio-info">
-                <div class="audio-name">Hyper...</div>
-                <div class="audio-sub">8.2k usages today</div>
-              </div>
-              <button type="button" class="audio-add" onclick="showToast('Added to project!')">+</button>
-            </div>
+          <div class="audio-list" id="audioList">
+            <div class="panel-empty" id="audioEmpty">Music recommendations appear only from a successful AI response. Templates never invent songs.</div>
           </div>
         </div>
-
       </div>
     </div><!-- /tool-grid -->
 
   </div><!-- /main-content -->
 </div><!-- /suggestions-page -->
 
-<!-- Mobile bottom nav -->
 <nav class="mobile-nav">
   <div class="mobile-nav-inner">
     <a href="/dashboard" class="mobile-nav-item">
@@ -219,108 +164,179 @@
   </div>
 </nav>
 
-<!-- Toast -->
 <div class="toast" id="toast"></div>
 
-<% if (typeof error !== 'undefined' && error) { %>
 <script nonce="<%= nonce %>">
-  document.addEventListener('DOMContentLoaded', () => {
-    const t = document.getElementById('toast');
-    if (t) {
-      t.textContent = "<%= error %>";
-      t.classList.add('show');
-      setTimeout(() => t.classList.remove('show'), 3500);
-    }
-  });
-</script>
-<% } %>
+  const initialResult = <%- typeof result !== 'undefined' && result ? JSON.stringify({
+    captions: result.captions || [],
+    hashtags: result.hashtags || [],
+    songs: result.songs || [],
+    source: typeof source !== 'undefined' ? source : (result.source || null)
+  }).replace(/</g, '\\u003c') : 'null' %>;
+  const initialError = <%- typeof error !== 'undefined' && error ? JSON.stringify({
+    message: error,
+    code: typeof errorCode !== 'undefined' ? errorCode : null,
+    retryable: typeof retryable !== 'undefined' ? !!retryable : false
+  }).replace(/</g, '\\u003c') : 'null' %>;
 
-<script nonce="<%= nonce %>">
-  // ── PLATFORM TOGGLE ──
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
   function togglePlatform(el) {
     el.classList.toggle('selected');
   }
 
-  // ── MOOD TOGGLE ──
   function toggleMood(el) {
     el.classList.toggle('selected');
   }
 
-  // ── CAPTION DATA ──
-  const captionTemplates = {
-    witty: [
-      {
-        label: 'OPTION 01: WITTY',
-        text: "My morning routine: 5% actual work, 95% making sure my desk looks like a Pinterest board. 🖥️✨ Who else is guilty of the 'productive aesthetic'? #CreatorLife #WorkspaceVibes",
-        tags: ['#CreatorEconomy', '#MorningRoutine', '#ProductivityHacks']
-      },
-      {
-        label: 'OPTION 02: WITTY ALT',
-        text: "POV: You've rearranged your desk 4 times but only moved the plant. 🌿 The real productivity hack nobody talks about. Drop a 🖥️ if you relate.",
-        tags: ['#DeskSetup', '#CreatorLife', '#WorkFromHome']
-      }
-    ],
-    professional: [
-      {
-        label: 'OPTION 01: PROFESSIONAL',
-        text: "Efficiency starts with environment. 🧠 Optimizing my physical workspace has led to a 40% increase in deep work hours this month. Here's a breakdown of the tools keeping me focused.",
-        tags: ['#WorkspaceOptimization', '#DeepWork']
-      },
-      {
-        label: 'OPTION 02: PROFESSIONAL ALT',
-        text: "Your environment shapes your output. I spent 30 days redesigning my workspace — here's what changed about my productivity, creativity, and focus. The results surprised me.",
-        tags: ['#ProductivitySystem', '#CreatorWorkspace', '#FocusMode']
-      }
-    ],
-    energetic: [
-      {
-        label: 'OPTION 01: ENERGETIC',
-        text: "NEW SETUP DROP! 🚀⚡ I finally built the workspace of my dreams and I'm obsessed. Swipe to see the full tour and drop your fave element in the comments!",
-        tags: ['#SetupTour', '#NewSetup', '#CreatorSpace']
-      },
-      {
-        label: 'OPTION 02: ENERGETIC ALT',
-        text: "This desk setup is SENDING me 🔥 Spent the whole weekend on this and I have zero regrets. Would you work here? Tell me in the comments 👇",
-        tags: ['#DeskGoals', '#WorkspaceInspo', '#CreatorVibes']
-      }
-    ],
-    minimalist: [
-      {
-        label: 'OPTION 01: MINIMALIST',
-        text: "Less clutter. More clarity. A clean space for clear thinking.",
-        tags: ['#Minimalism', '#MinimalDesk', '#CleanSetup']
-      },
-      {
-        label: 'OPTION 02: MINIMALIST ALT',
-        text: "The desk. The work. Nothing else needed.",
-        tags: ['#MinimalWorkspace', '#SimpleLiving', '#Focus']
-      }
-    ]
-  };
+  function getCsrfToken() {
+    const page = document.querySelector('.suggestions-page');
+    return page ? page.getAttribute('data-csrf') || '' : '';
+  }
 
-  const trendingHashtags = {
-    instagram: [
-      { tag: '#CREATORECONOMY', score: 98 },
-      { tag: '#AIGENERATED', score: 85 },
-      { tag: '#PRODUCTIVITYHACKS', score: 72 },
-      { tag: '#DESKSETUP', score: 64 },
-    ],
-    tiktok: [
-      { tag: '#FYPAGE', score: 99 },
-      { tag: '#TIKTOKCREATOR', score: 91 },
-      { tag: '#VIRAL2026', score: 88 },
-      { tag: '#CONTENTCREATOR', score: 76 },
-    ],
-    youtube: [
-      { tag: '#YOUTUBER', score: 95 },
-      { tag: '#SHORTS', score: 90 },
-      { tag: '#VLOG', score: 82 },
-      { tag: '#SUBSCRIBE', score: 70 },
-    ]
-  };
+  function showToast(msg) {
+    const t = document.getElementById('toast');
+    t.textContent = msg;
+    t.classList.add('show');
+    setTimeout(() => t.classList.remove('show'), 2500);
+  }
 
-  // ── GENERATE ──
-  function generateCaptions() {
+  function setStatusBanner({ type, title, message, retryable }) {
+    const banner = document.getElementById('statusBanner');
+    const titleEl = document.getElementById('statusBannerTitle');
+    const messageEl = document.getElementById('statusBannerMessage');
+    const retryBtn = document.getElementById('statusRetryBtn');
+
+    banner.hidden = false;
+    banner.classList.add('show');
+    banner.classList.toggle('error', type === 'error');
+    banner.classList.toggle('template', type === 'template');
+    titleEl.textContent = title;
+    messageEl.textContent = message;
+    retryBtn.hidden = !retryable;
+  }
+
+  function clearStatusBanner() {
+    const banner = document.getElementById('statusBanner');
+    banner.hidden = true;
+    banner.classList.remove('show', 'error', 'template');
+    document.getElementById('statusRetryBtn').hidden = true;
+  }
+
+  function showUnavailableState(message, retryable) {
+    const list = document.getElementById('captionsList');
+    list.innerHTML = `
+      <div class="empty-state unavailable-state" id="emptyState">
+        <div class="empty-icon">
+          <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        </div>
+        <div class="empty-title">Suggestions unavailable</div>
+        <div class="empty-sub">${escapeHtml(message || 'Generation failed. Please try again.')}</div>
+        ${retryable ? '<button type="button" class="status-retry-btn" onclick="generateCaptions()">Retry</button>' : ''}
+      </div>
+    `;
+    document.getElementById('hashtagList').innerHTML =
+      '<div class="panel-empty">Hashtags unavailable until generation succeeds.</div>';
+    document.getElementById('audioList').innerHTML =
+      '<div class="panel-empty">Music recommendations are hidden when generation fails.</div>';
+    setStatusBanner({
+      type: 'error',
+      title: 'Suggestions unavailable',
+      message: message || 'Generation failed. Please try again.',
+      retryable: !!retryable
+    });
+  }
+
+  function renderCaptions(captions, hashtags, source) {
+    const list = document.getElementById('captionsList');
+    list.innerHTML = captions.map((text, i) => `
+      <div class="caption-card" style="animation-delay:${i * 0.08}s">
+        <span class="caption-option-label">OPTION ${String(i + 1).padStart(2, '0')}${source === 'template' ? ' · TEMPLATE' : ''}</span>
+        <p class="caption-text">${escapeHtml(text)}</p>
+        <div class="caption-tags">
+          ${hashtags.slice(0, 3).map((t) =>
+            `<span class="caption-tag" data-text="${escapeHtml(t)}">${escapeHtml(t)}</span>`
+          ).join('')}
+        </div>
+        <div class="caption-actions">
+          <button type="button" class="caption-btn" data-copy-index="${i}">
+            <svg viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+            COPY
+          </button>
+        </div>
+      </div>
+    `).join('');
+
+    list.querySelectorAll('.caption-tag').forEach((tag) => {
+      tag.addEventListener('click', () => copyText(tag.getAttribute('data-text')));
+    });
+    list.querySelectorAll('[data-copy-index]').forEach((btn) => {
+      btn.addEventListener('click', () => copyCaption(Number(btn.getAttribute('data-copy-index'))));
+    });
+  }
+
+  function renderHashtags(hashtags) {
+    const list = document.getElementById('hashtagList');
+    if (!hashtags.length) {
+      list.innerHTML = '<div class="panel-empty">No hashtags returned.</div>';
+      return;
+    }
+    list.innerHTML = hashtags.map((tag) => `
+      <div class="hashtag-row" data-tag="${escapeHtml(tag)}">
+        <span class="hashtag-name">${escapeHtml(tag)}</span>
+      </div>
+    `).join('');
+    list.querySelectorAll('.hashtag-row').forEach((row) => {
+      row.addEventListener('click', () => copyHashtag(row.getAttribute('data-tag')));
+    });
+  }
+
+  function renderSongs(songs, source) {
+    const list = document.getElementById('audioList');
+    if (source === 'template' || !songs || songs.length === 0) {
+      list.innerHTML = '<div class="panel-empty">No verified music recommendations for this result.</div>';
+      return;
+    }
+    list.innerHTML = songs.map((song) => `
+      <div class="audio-row">
+        <div class="audio-play">
+          <svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3" fill="#fff"/></svg>
+        </div>
+        <div class="audio-info">
+          <div class="audio-name">${escapeHtml(song.title)}</div>
+          <div class="audio-sub">${escapeHtml(song.mood || 'AI suggestion')}</div>
+        </div>
+      </div>
+    `).join('');
+  }
+
+  function applyResult(payload) {
+    const source = payload.source || (payload.isTemplate ? 'template' : 'openai');
+    const result = payload.result || payload;
+    renderCaptions(result.captions || [], result.hashtags || [], source);
+    renderHashtags(result.hashtags || []);
+    renderSongs(result.songs || [], source);
+
+    if (source === 'template') {
+      setStatusBanner({
+        type: 'template',
+        title: 'Template mode',
+        message: 'These captions and hashtags are offline templates, not AI-generated results. Music recommendations are omitted.',
+        retryable: false
+      });
+    } else {
+      clearStatusBanner();
+    }
+  }
+
+  async function generateCaptions() {
     const topic = document.getElementById('topicInput').value.trim();
     if (!topic) {
       showToast('Please enter a topic first!');
@@ -329,75 +345,45 @@
 
     const btn = document.getElementById('generateBtn');
     btn.classList.add('loading');
+    btn.disabled = true;
 
-    // Get selected mood
-    const selectedMood = document.querySelector('.mood-chip.selected');
-    const mood = selectedMood ? selectedMood.textContent.toLowerCase() : 'energetic';
+    try {
+      const response = await fetch('/suggestions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'X-CSRF-Token': getCsrfToken()
+        },
+        body: JSON.stringify({ topic })
+      });
 
-    // Get selected platforms
-    const selectedPlatforms = [...document.querySelectorAll('.platform-chip.selected')]
-      .map(el => el.dataset.platform);
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.success) {
+        showUnavailableState(
+          data.message || data.error || 'AI suggestions are temporarily unavailable.',
+          data.retryable !== false
+        );
+        return;
+      }
 
-    setTimeout(() => {
-      btn.classList.remove('loading');
-      renderCaptions(mood, topic, selectedPlatforms);
-      updateHashtags(selectedPlatforms[0] || 'instagram');
+      applyResult(data);
       updateUsage();
-    }, 1200);
-  }
-
-  function renderCaptions(mood, topic, platforms) {
-    const list = document.getElementById('captionsList');
-    const empty = document.getElementById('emptyState');
-    if (empty) empty.remove();
-
-    const captions = captionTemplates[mood] || captionTemplates.energetic;
-
-    list.innerHTML = captions.map((c, i) => `
-      <div class="caption-card" style="animation-delay:${i*0.08}s">
-        <span class="caption-option-label">${c.label}</span>
-        <p class="caption-text">${c.text}</p>
-        <div class="caption-tags">
-          ${c.tags.map(t => `<span class="caption-tag" onclick="copyText('${t}')">${t}</span>`).join('')}
-        </div>
-        <div class="caption-actions">
-          <button type="button" class="caption-btn" onclick="copyCaption(${i})">
-            <svg viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-            COPY
-          </button>
-          <button type="button" class="caption-btn" onclick="showToast('Edit mode coming soon!')">
-            <svg viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-            EDIT
-          </button>
-        </div>
-      </div>
-    `).join('');
-  }
-
-  function updateHashtags(platform) {
-    const hashtags = trendingHashtags[platform] || trendingHashtags.instagram;
-    const list = document.getElementById('hashtagList');
-    list.innerHTML = hashtags.map(h => `
-      <div class="hashtag-row" onclick="copyHashtag('${h.tag}')">
-        <span class="hashtag-name">${h.tag}</span>
-        <div class="hashtag-score-wrap">
-          <span class="hashtag-score">${h.score}/100</span>
-          <div class="hashtag-bar-bg"><div class="hashtag-bar" style="width:${h.score}%"></div></div>
-        </div>
-      </div>
-    `).join('');
+    } catch (err) {
+      showUnavailableState('Could not reach the suggestions service. Please try again.', true);
+    } finally {
+      btn.classList.remove('loading');
+      btn.disabled = false;
+    }
   }
 
   function updateUsage() {
-    const used = Math.min(95, parseInt(document.getElementById('usagePct').textContent) + 1);
+    const used = Math.min(95, parseInt(document.getElementById('usagePct').textContent, 10) + 1);
     document.getElementById('usagePct').textContent = used + '%';
     document.getElementById('usageBar').style.width = used + '%';
     const remaining = Math.max(0, 150 - Math.round(150 * used / 100));
     document.getElementById('usageSub').textContent = `${remaining} / 150 requests remaining this month.`;
   }
-
-  // ── COPY HELPERS ──
-  const captionTexts = [];
 
   function copyCaption(index) {
     const cards = document.querySelectorAll('.caption-card');
@@ -418,17 +404,18 @@
     showToast(`${tag} copied!`);
   }
 
-  // ── TOAST ──
-  function showToast(msg) {
-    const t = document.getElementById('toast');
-    t.textContent = msg;
-    t.classList.add('show');
-    setTimeout(() => t.classList.remove('show'), 2000);
-  }
-
-  // ── ENTER TO GENERATE ──
-  document.getElementById('topicInput').addEventListener('keydown', e => {
+  document.getElementById('topicInput').addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && e.ctrlKey) generateCaptions();
+  });
+
+  document.getElementById('statusRetryBtn').addEventListener('click', () => generateCaptions());
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (initialResult) {
+      applyResult(initialResult);
+    } else if (initialError) {
+      showUnavailableState(initialError.message, initialError.retryable);
+    }
   });
 </script>
 


### PR DESCRIPTION
## Description
Provider failures on `/suggestions` no longer return invented captions/hashtags/songs as a successful generation. Missing config, timeouts, and bad JSON now surface an unavailable/retry state. Offline templates only run when `SUGGESTIONS_TEMPLATE_MODE=true`, are labelled, and never invent songs.

## Related Issues
Fixes #881

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Style changes
- [ ] Performance improvement
- [x] Test update

## Changes Made
- Throw explicit `SuggestionProviderError` codes instead of silent mock fallback
- Gate offline templates behind `SUGGESTIONS_TEMPLATE_MODE` and omit songs there
- Wire the suggestions page to the real endpoint with provenance banner + retry UI
- Add regression coverage for success, missing config, timeout, invalid JSON, and template mode

## Testing

### How to Test
1. With no `OPENAI_API_KEY` and template mode off, generate suggestions and confirm unavailable/retry UI (no fake success)
2. Set `SUGGESTIONS_TEMPLATE_MODE=true`, generate again, confirm labelled template captions/hashtags and no invented songs
3. With a valid key and mocked/real provider success, confirm `source: openai` results render normally

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Screenshots (if applicable)
N/A

## Deployment Notes
Optional: set `SUGGESTIONS_TEMPLATE_MODE=true` only if offline templates are intentionally wanted.

## Breaking Changes
- None for configured OpenAI setups. Unconfigured environments now get an error instead of silent fake results unless template mode is enabled.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## Additional Context
Focused on the silent fallback in `suggestionController.js` and making the page show provenance/failure instead of client-side fake success.

Made with [Cursor](https://cursor.com)