### PR TITLE
fix(auth): refuse Google OAuth link on unverified local accounts

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -6,6 +6,7 @@ const { signupValidator, loginValidator, contributorLoginValidator, resendVerifi
 const connectDB = require("../connect");
 const { loginLimiter, signupLimiter, emailVerificationLimiter, forgotPasswordLimiter, resetPasswordLimiter } = require("../middleware/rateLimiters");
 const { redirectIfAuthenticated } = require("../middleware/auth");
+const { resolveGoogleOAuthUser } = require("../utils/resolveGoogleOAuthUser");
 
 const router = express.Router();
 
@@ -27,43 +28,13 @@ if (googleAuthConfigured) {
                 try {
                     await connectDB();
                     const User = require("../model/user");
-                    const email = profile.emails?.[0]?.value?.toLowerCase();
+                    const result = await resolveGoogleOAuthUser(profile, User);
 
-                    if (!email) {
-                        return done(null, false, { message: "Google account does not expose an email address." });
+                    if (!result.ok) {
+                        return done(null, false, { message: result.message });
                     }
 
-                    const googleUser = {
-                        googleId: profile.id,
-                        name: profile.displayName || email.split("@")[0],
-                        email,
-                        avatar: profile.photos?.[0]?.value,
-                        lastLoginAt: new Date(),
-                    };
-
-                    let user = await User.findOne({ googleId: profile.id });
-
-                    if (!user) {
-                        user = await User.findOne({ email });
-                    }
-
-                    if (user) {
-                        user.googleId = googleUser.googleId;
-                        user.name = user.name || googleUser.name;
-                        user.avatar = googleUser.avatar || user.avatar;
-                        user.authProvider = user.password ? user.authProvider : "google";
-                        user.lastLoginAt = googleUser.lastLoginAt;
-                        user.isVerified = true;
-                        await user.save();
-                    } else {
-                        user = await User.create({
-                            ...googleUser,
-                            authProvider: "google",
-                            isVerified: true,
-                        });
-                    }
-
-                    return done(null, user);
+                    return done(null, result.user);
                 } catch (error) {
                     return done(error);
                 }

--- a/tests/utils/resolveGoogleOAuthUser.test.js
+++ b/tests/utils/resolveGoogleOAuthUser.test.js
@@ -1,0 +1,113 @@
+const { resolveGoogleOAuthUser } = require("../../utils/resolveGoogleOAuthUser");
+
+function createUserDoc(overrides = {}) {
+  return {
+    googleId: undefined,
+    name: "Local User",
+    email: "victim@gmail.com",
+    avatar: null,
+    password: "hashed",
+    authProvider: "local",
+    isVerified: false,
+    lastLoginAt: null,
+    save: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function createUserModel({ byGoogleId = null, byEmail = null, created = null } = {}) {
+  return {
+    findOne: jest.fn(async (query) => {
+      if (query.googleId) return byGoogleId;
+      if (query.email) return byEmail;
+      return null;
+    }),
+    create: jest.fn(async (doc) => created || { ...doc, save: jest.fn() }),
+  };
+}
+
+const profile = {
+  id: "google-123",
+  displayName: "Victim Name",
+  emails: [{ value: "Victim@Gmail.com" }],
+  photos: [{ value: "https://example.com/avatar.png" }],
+};
+
+describe("resolveGoogleOAuthUser (#978)", () => {
+  it("refuses to link Google onto an unverified local account", async () => {
+    const unverified = createUserDoc({ isVerified: false });
+    const User = createUserModel({ byEmail: unverified });
+
+    const result = await resolveGoogleOAuthUser(profile, User);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/not verified/i);
+    expect(unverified.googleId).toBeUndefined();
+    expect(unverified.isVerified).toBe(false);
+    expect(unverified.save).not.toHaveBeenCalled();
+    expect(User.create).not.toHaveBeenCalled();
+  });
+
+  it("links Google onto a verified local account without changing verification", async () => {
+    const verified = createUserDoc({ isVerified: true });
+    const User = createUserModel({ byEmail: verified });
+
+    const result = await resolveGoogleOAuthUser(profile, User);
+
+    expect(result.ok).toBe(true);
+    expect(result.user.googleId).toBe("google-123");
+    expect(result.user.isVerified).toBe(true);
+    expect(verified.save).toHaveBeenCalled();
+  });
+
+  it("updates an existing Google-linked user", async () => {
+    const existing = createUserDoc({
+      googleId: "google-123",
+      isVerified: true,
+      name: "",
+    });
+    const User = createUserModel({ byGoogleId: existing });
+
+    const result = await resolveGoogleOAuthUser(profile, User);
+
+    expect(result.ok).toBe(true);
+    expect(User.findOne).toHaveBeenCalledWith({ googleId: "google-123" });
+    expect(existing.name).toBe("Victim Name");
+    expect(existing.isVerified).toBe(true);
+    expect(existing.save).toHaveBeenCalled();
+  });
+
+  it("creates a new verified Google user when email is unused", async () => {
+    const created = createUserDoc({
+      googleId: "google-123",
+      isVerified: true,
+      authProvider: "google",
+      password: undefined,
+    });
+    const User = createUserModel({ created });
+
+    const result = await resolveGoogleOAuthUser(profile, User);
+
+    expect(result.ok).toBe(true);
+    expect(User.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        googleId: "google-123",
+        email: "victim@gmail.com",
+        authProvider: "google",
+        isVerified: true,
+      })
+    );
+  });
+
+  it("fails when Google profile has no email", async () => {
+    const User = createUserModel();
+    const result = await resolveGoogleOAuthUser(
+      { id: "google-123", emails: [], displayName: "No Email" },
+      User
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/email/i);
+    expect(User.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/utils/resolveGoogleOAuthUser.js
+++ b/utils/resolveGoogleOAuthUser.js
@@ -1,0 +1,64 @@
+/**
+ * Resolve a Google OAuth profile to a local user without taking over
+ * unverified email/password accounts (pre-registration attack).
+ */
+async function resolveGoogleOAuthUser(profile, User) {
+    const email = profile.emails?.[0]?.value?.toLowerCase();
+
+    if (!email) {
+        return { ok: false, message: "Google account does not expose an email address." };
+    }
+
+    const googleUser = {
+        googleId: profile.id,
+        name: profile.displayName || email.split("@")[0],
+        email,
+        avatar: profile.photos?.[0]?.value,
+        lastLoginAt: new Date(),
+    };
+
+    let user = await User.findOne({ googleId: profile.id });
+
+    if (user) {
+        user.name = user.name || googleUser.name;
+        user.avatar = googleUser.avatar || user.avatar;
+        user.authProvider = user.password ? user.authProvider : "google";
+        user.lastLoginAt = googleUser.lastLoginAt;
+        user.isVerified = true;
+        await user.save();
+        return { ok: true, user };
+    }
+
+    user = await User.findOne({ email });
+
+    if (user) {
+        const alreadyLinkedToThisGoogle =
+            user.googleId && String(user.googleId) === String(googleUser.googleId);
+
+        if (!user.isVerified && !alreadyLinkedToThisGoogle) {
+            return {
+                ok: false,
+                message:
+                    "Account exists but is not verified. Verify email or use password login after verification.",
+            };
+        }
+
+        user.googleId = googleUser.googleId;
+        user.name = user.name || googleUser.name;
+        user.avatar = googleUser.avatar || user.avatar;
+        user.authProvider = user.password ? user.authProvider : "google";
+        user.lastLoginAt = googleUser.lastLoginAt;
+        // Keep existing verified status; do not elevate unverified accounts here.
+        await user.save();
+        return { ok: true, user };
+    }
+
+    user = await User.create({
+        ...googleUser,
+        authProvider: "google",
+        isVerified: true,
+    });
+    return { ok: true, user };
+}
+
+module.exports = { resolveGoogleOAuthUser };


### PR DESCRIPTION
## Description
Stop Google OAuth from auto-linking onto unverified local accounts, which previously enabled pre-registration account takeover.

## Related Issues
Fixes #978

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Style changes
- [ ] Performance improvement
- [x] Test update

## Changes Made
- Extract Google profile resolution into `utils/resolveGoogleOAuthUser.js`
- Refuse email-match linking when the local account is unverified
- Still link verified local accounts and update existing googleId users
- Keep creating new verified Google users when the email is unused

## Testing

### How to Test
1. Sign up locally with an email and leave the account unverified
2. Attempt Google sign-in with that same email
3. Confirm OAuth fails instead of merging into the unverified row
4. Verify a verified local account still links Google normally

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Screenshots (if applicable)
N/A

## Deployment Notes
None

## Breaking Changes
- None

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## Additional Context
Attackers could previously register an unverified local account for a victim Google email, then take over after the victim signed in with Google.