### PR TITLE
fix(security): block SSRF via QR logoUrl fetches

### DIFF
--- a/controller/qrCodeController.js
+++ b/controller/qrCodeController.js
@@ -6,6 +6,7 @@ const User = require('../model/user');
 const services = require('../services.config');
 const asyncHandler = require('../utils/asyncHandler');
 const { isValidUrl } = require('../utils/validators');
+const { assertSafePublicHttpUrl } = require('../utils/ssrf');
 const {
     resolveErrorCorrection,
     buildEncodedUrl,
@@ -70,10 +71,11 @@ function getBaseUrl(req) {
 /**
  * @function normalizeDesign
  * @description Sanitizes design payload from the client.
+ * Rejects logoUrl values that fail SSRF checks (private/link-local/ULA/etc).
  * @param {object} raw
- * @returns {object}
+ * @returns {Promise<object>}
  */
-function normalizeDesign(raw = {}) {
+async function normalizeDesign(raw = {}) {
     const foregroundColor = typeof raw.foregroundColor === 'string' && /^#[0-9A-Fa-f]{6}$/.test(raw.foregroundColor)
         ? raw.foregroundColor
         : '#000000';
@@ -81,7 +83,24 @@ function normalizeDesign(raw = {}) {
         ? raw.backgroundColor
         : '#FFFFFF';
     const patternPreset = PATTERN_PRESETS.includes(raw.patternPreset) ? raw.patternPreset : 'A';
-    const logoUrl = typeof raw.logoUrl === 'string' && isValidUrl(raw.logoUrl) ? raw.logoUrl : null;
+
+    let logoUrl = null;
+    if (typeof raw.logoUrl === 'string' && raw.logoUrl.trim()) {
+        const candidate = raw.logoUrl.trim();
+        if (!isValidUrl(candidate)) {
+            const err = new Error('logoUrl must be a valid HTTP or HTTPS URL');
+            err.statusCode = 400;
+            throw err;
+        }
+        try {
+            await assertSafePublicHttpUrl(candidate);
+        } catch (ssrfErr) {
+            const err = new Error(ssrfErr.message || 'logoUrl is not allowed');
+            err.statusCode = 400;
+            throw err;
+        }
+        logoUrl = candidate;
+    }
 
     return {
         foregroundColor,
@@ -318,7 +337,17 @@ const createQrCode = asyncHandler(async (req, res) => {
     }
 
     const dynamic = inputType === 'url' && isDynamic !== false && autoShortLink !== false;
-    const design = normalizeDesign(rawDesign || {});
+    let design;
+    try {
+        design = await normalizeDesign(rawDesign || {});
+    } catch (err) {
+        const message = err.message || 'Invalid QR design';
+        return res.status(err.statusCode || 400).json({
+            success: false,
+            message,
+            error: message,
+        });
+    }
     const doc = await createQrDocument({
         userId: req.user.id,
         targetUrl: encodedContent,
@@ -363,7 +392,17 @@ const batchCreateQrCodes = asyncHandler(async (req, res) => {
         });
     }
 
-    const design = normalizeDesign(rawDesign || {});
+    let design;
+    try {
+        design = await normalizeDesign(rawDesign || {});
+    } catch (err) {
+        const message = err.message || 'Invalid QR design';
+        return res.status(err.statusCode || 400).json({
+            success: false,
+            message,
+            error: message,
+        });
+    }
     const batchId = new mongoose.Types.ObjectId();
     const baseUrl = getBaseUrl(req);
     const created = [];
@@ -540,7 +579,16 @@ const updateQrCode = asyncHandler(async (req, res) => {
     }
 
     if (rawDesign && typeof rawDesign === 'object') {
-        doc.design = normalizeDesign({ ...doc.design?.toObject?.() || doc.design || {}, ...rawDesign });
+        try {
+            doc.design = await normalizeDesign({ ...doc.design?.toObject?.() || doc.design || {}, ...rawDesign });
+        } catch (err) {
+            const message = err.message || 'Invalid QR design';
+            return res.status(err.statusCode || 400).json({
+                success: false,
+                message,
+                error: message,
+            });
+        }
     }
 
     await doc.save();

--- a/tests/utils/ssrf.test.js
+++ b/tests/utils/ssrf.test.js
@@ -1,0 +1,98 @@
+const dns = require('dns');
+const {
+    isPrivateIP,
+    stripHostnameBrackets,
+    assertSafePublicHttpUrl,
+} = require('../../utils/ssrf');
+
+describe('ssrf helpers', () => {
+    describe('stripHostnameBrackets', () => {
+        it('strips brackets from IPv6 hostnames', () => {
+            expect(stripHostnameBrackets('[::1]')).toBe('::1');
+            expect(stripHostnameBrackets('[fe80::1]')).toBe('fe80::1');
+        });
+
+        it('lowercases hostnames without brackets', () => {
+            expect(stripHostnameBrackets('Example.COM')).toBe('example.com');
+        });
+    });
+
+    describe('isPrivateIP', () => {
+        it('blocks private and loopback IPv4 addresses', () => {
+            expect(isPrivateIP('127.0.0.1')).toBe(true);
+            expect(isPrivateIP('10.0.0.5')).toBe(true);
+            expect(isPrivateIP('192.168.1.10')).toBe(true);
+            expect(isPrivateIP('172.16.0.1')).toBe(true);
+            expect(isPrivateIP('169.254.169.254')).toBe(true);
+            expect(isPrivateIP('100.64.0.1')).toBe(true);
+            expect(isPrivateIP('0.0.0.0')).toBe(true);
+        });
+
+        it('blocks IPv6 loopback, link-local, and ULA addresses', () => {
+            expect(isPrivateIP('::1')).toBe(true);
+            expect(isPrivateIP('[::1]')).toBe(true);
+            expect(isPrivateIP('fe80::1')).toBe(true);
+            expect(isPrivateIP('fc00::1')).toBe(true);
+            expect(isPrivateIP('fd12:3456:789a::1')).toBe(true);
+            expect(isPrivateIP('::ffff:127.0.0.1')).toBe(true);
+            expect(isPrivateIP('::ffff:169.254.169.254')).toBe(true);
+        });
+
+        it('allows public addresses', () => {
+            expect(isPrivateIP('8.8.8.8')).toBe(false);
+            expect(isPrivateIP('1.1.1.1')).toBe(false);
+            expect(isPrivateIP('2001:4860:4860::8888')).toBe(false);
+        });
+    });
+
+    describe('assertSafePublicHttpUrl', () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('rejects non-http protocols', async () => {
+            await expect(assertSafePublicHttpUrl('javascript:alert(1)')).rejects.toThrow(
+                /Only HTTP and HTTPS/
+            );
+            await expect(assertSafePublicHttpUrl('ftp://example.com/logo.png')).rejects.toThrow(
+                /Only HTTP and HTTPS/
+            );
+        });
+
+        it('rejects localhost and private IP literals', async () => {
+            await expect(assertSafePublicHttpUrl('http://localhost/logo.png')).rejects.toThrow(
+                /private or internal/
+            );
+            await expect(assertSafePublicHttpUrl('http://127.0.0.1/logo.png')).rejects.toThrow(
+                /private or internal/
+            );
+            await expect(assertSafePublicHttpUrl('http://169.254.169.254/latest/meta-data/')).rejects.toThrow(
+                /private or internal/
+            );
+            await expect(assertSafePublicHttpUrl('http://[::1]/logo.png')).rejects.toThrow(
+                /private or internal/
+            );
+            await expect(assertSafePublicHttpUrl('http://[fe80::1]/logo.png')).rejects.toThrow(
+                /private or internal/
+            );
+        });
+
+        it('rejects hostnames that resolve to private addresses', async () => {
+            jest.spyOn(dns, 'lookup').mockImplementation((hostname, options, callback) => {
+                callback(null, [{ address: '127.0.0.1', family: 4 }]);
+            });
+
+            await expect(assertSafePublicHttpUrl('https://evil.example/logo.png')).rejects.toThrow(
+                /resolves to a private/
+            );
+        });
+
+        it('allows public http(s) URLs whose DNS is public', async () => {
+            jest.spyOn(dns, 'lookup').mockImplementation((hostname, options, callback) => {
+                callback(null, [{ address: '93.184.216.34', family: 4 }]);
+            });
+
+            await expect(assertSafePublicHttpUrl('https://example.com/logo.png')).resolves.toBeInstanceOf(URL);
+        });
+    });
+});

--- a/utils/qrGenerator.js
+++ b/utils/qrGenerator.js
@@ -1,6 +1,7 @@
 const QRCode = require('qrcode');
 const PDFDocument = require('pdfkit');
 const sharp = require('sharp');
+const { assertSafePublicHttpUrl } = require('./ssrf');
 
 /**
  * Pattern presets map to visual module styles.
@@ -166,8 +167,10 @@ async function compositeLogo(pngBuffer, logoUrl) {
     if (!logoUrl) return pngBuffer;
 
     try {
+        await assertSafePublicHttpUrl(logoUrl);
         const response = await fetch(logoUrl, {
             signal: AbortSignal.timeout(5000),
+            redirect: 'error',
         });
         if (!response.ok) return pngBuffer;
 

--- a/utils/ssrf.js
+++ b/utils/ssrf.js
@@ -1,0 +1,208 @@
+const dns = require('dns');
+const net = require('net');
+
+/**
+ * @function stripHostnameBrackets
+ * @description Removes surrounding brackets from IPv6 hostnames (e.g. "[::1]" → "::1").
+ * @param {string} hostname
+ * @returns {string}
+ */
+function stripHostnameBrackets(hostname) {
+    if (typeof hostname !== 'string') return '';
+    const trimmed = hostname.trim().toLowerCase();
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+        return trimmed.slice(1, -1);
+    }
+    return trimmed;
+}
+
+/**
+ * @function isPrivateIPv4
+ * @param {string} ip
+ * @returns {boolean}
+ */
+function isPrivateIPv4(ip) {
+    const parts = ip.split('.').map(Number);
+    if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
+        return false;
+    }
+
+    // 0.0.0.0/8
+    if (parts[0] === 0) return true;
+    // 10.0.0.0/8
+    if (parts[0] === 10) return true;
+    // 100.64.0.0/10 (CGNAT)
+    if (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true;
+    // 127.0.0.0/8
+    if (parts[0] === 127) return true;
+    // 169.254.0.0/16 (link-local / cloud metadata)
+    if (parts[0] === 169 && parts[1] === 254) return true;
+    // 172.16.0.0/12
+    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
+    // 192.168.0.0/16
+    if (parts[0] === 192 && parts[1] === 168) return true;
+    // 198.18.0.0/15 (benchmarking)
+    if (parts[0] === 198 && parts[1] >= 18 && parts[1] <= 19) return true;
+
+    return false;
+}
+
+/**
+ * @function expandIPv6
+ * @description Expands an IPv6 address into eight 16-bit hex groups.
+ * @param {string} ip
+ * @returns {string[]|null}
+ */
+function expandIPv6(ip) {
+    if (!net.isIPv6(ip)) return null;
+
+    let address = ip.toLowerCase();
+    if (address.startsWith('::ffff:')) {
+        const mapped = address.slice(7);
+        if (net.isIPv4(mapped)) {
+            const parts = mapped.split('.').map((part) => Number(part).toString(16).padStart(2, '0'));
+            address = `::ffff:${parts[0]}${parts[1]}:${parts[2]}${parts[3]}`;
+        }
+    }
+
+    const [left, right = ''] = address.split('::');
+    const leftParts = left ? left.split(':') : [];
+    const rightParts = right ? right.split(':') : [];
+    const missing = 8 - (leftParts.length + rightParts.length);
+    if (missing < 0) return null;
+
+    const parts = [
+        ...leftParts,
+        ...Array.from({ length: missing }, () => '0'),
+        ...rightParts,
+    ].map((part) => part.padStart(4, '0'));
+
+    return parts.length === 8 ? parts : null;
+}
+
+/**
+ * @function isPrivateIPv6
+ * @param {string} ip
+ * @returns {boolean}
+ */
+function isPrivateIPv6(ip) {
+    const parts = expandIPv6(ip);
+    if (!parts) return false;
+
+    const first = parseInt(parts[0], 16);
+
+    // :: and ::1 (unspecified / loopback)
+    if (parts.every((part) => part === '0000')) return true;
+    if (
+        parts.slice(0, 7).every((part) => part === '0000') &&
+        parts[7] === '0001'
+    ) {
+        return true;
+    }
+
+    // IPv4-mapped / IPv4-compatible — check embedded IPv4
+    if (
+        parts.slice(0, 5).every((part) => part === '0000') &&
+        (parts[5] === '0000' || parts[5] === 'ffff')
+    ) {
+        const hi = parseInt(parts[6], 16);
+        const lo = parseInt(parts[7], 16);
+        const mapped = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+        return isPrivateIPv4(mapped);
+    }
+
+    // fe80::/10 link-local
+    if ((first & 0xffc0) === 0xfe80) return true;
+    // fc00::/7 unique local (ULA)
+    if ((first & 0xfe00) === 0xfc00) return true;
+
+    return false;
+}
+
+/**
+ * @function isPrivateIP
+ * @description Returns true for private, loopback, link-local, ULA, CGNAT, and metadata ranges.
+ * @param {string} ip
+ * @returns {boolean}
+ */
+function isPrivateIP(ip) {
+    if (typeof ip !== 'string' || !ip) return false;
+    const normalized = stripHostnameBrackets(ip);
+
+    if (net.isIPv4(normalized)) return isPrivateIPv4(normalized);
+    if (net.isIPv6(normalized)) return isPrivateIPv6(normalized);
+    return false;
+}
+
+/**
+ * @function lookupAllAddresses
+ * @param {string} hostname
+ * @returns {Promise<string[]>}
+ */
+function lookupAllAddresses(hostname) {
+    return new Promise((resolve) => {
+        dns.lookup(hostname, { all: true }, (err, addrs) => {
+            if (err || !Array.isArray(addrs)) {
+                resolve([]);
+                return;
+            }
+            resolve(addrs.map((entry) => entry.address));
+        });
+    });
+}
+
+/**
+ * @function assertSafePublicHttpUrl
+ * @description Ensures a URL is http(s) and does not target private/internal addresses.
+ * Performs DNS resolution and re-checks every returned address.
+ * @param {string} urlString
+ * @returns {Promise<URL>}
+ */
+async function assertSafePublicHttpUrl(urlString) {
+    if (typeof urlString !== 'string' || !urlString.trim()) {
+        throw new Error('Invalid URL');
+    }
+
+    let parsed;
+    try {
+        parsed = new URL(urlString.trim());
+    } catch {
+        throw new Error('Invalid URL');
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new Error('Only HTTP and HTTPS URLs are allowed');
+    }
+
+    const hostname = stripHostnameBrackets(parsed.hostname);
+    if (!hostname) {
+        throw new Error('Invalid URL hostname');
+    }
+
+    if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+        throw new Error('URL points to a private or internal network address');
+    }
+
+    if (net.isIP(hostname) && isPrivateIP(hostname)) {
+        throw new Error('URL points to a private or internal network address');
+    }
+
+    const addresses = await lookupAllAddresses(hostname);
+    if (!addresses.length && !net.isIP(hostname)) {
+        throw new Error('Unable to resolve URL hostname');
+    }
+
+    for (const addr of addresses) {
+        if (isPrivateIP(addr)) {
+            throw new Error('URL resolves to a private or internal network address');
+        }
+    }
+
+    return parsed;
+}
+
+module.exports = {
+    stripHostnameBrackets,
+    isPrivateIP,
+    assertSafePublicHttpUrl,
+};


### PR DESCRIPTION
## Description
QR logo compositing fetched arbitrary `logoUrl` values after a basic http(s) check, allowing authenticated SSRF to private/link-local addresses and cloud metadata.

## Related Issues
Fixes #985

## Type of Change
- [x] Bug fix
- [x] Security fix

## Changes Made
- Add `utils/ssrf.js` with public URL assertion (protocol allowlist, private IP block, IPv6 bracket strip, DNS re-check)
- Guard `compositeLogo` fetch and reject unsafe `logoUrl` in the QR controller with 400
- Add SSRF helper unit tests

## Testing
- [x] `npm test -- tests/utils/ssrf.test.js`
- [ ] Create QR with public logoUrl still works
- [ ] Create QR with `logoUrl=http://127.0.0.1/` or metadata IP returns 400