### PR TITLE
fix(instagram): mark webhook events processed only after enqueue

### DIFF
--- a/controller/instagramWebhookController.js
+++ b/controller/instagramWebhookController.js
@@ -1,7 +1,10 @@
-const { dmQueue } = require('../services/dmQueueService');
+const dmQueueService = require('../services/dmQueueService');
 const asyncHandler = require('../utils/asyncHandler');
 
 const crypto = require('crypto');
+
+// Prefer exported dmQueue when present (#981 may add the export separately).
+const dmQueue = dmQueueService && dmQueueService.dmQueue;
 
 // In-memory deduplication set for processed webhook event IDs
 // TTL: 5 minutes to prevent unbounded memory growth
@@ -19,11 +22,18 @@ const cleanupInterval = setInterval(() => {
 }, 60 * 1000);
 cleanupInterval.unref();
 
-function isEventAlreadyProcessed(eventId) {
+function hasProcessed(eventId) {
     if (!eventId) return false;
-    if (processedEvents.has(eventId)) return true;
+    return processedEvents.has(eventId);
+}
+
+function markProcessed(eventId) {
+    if (!eventId) return;
     processedEvents.set(eventId, Date.now());
-    return false;
+}
+
+function clearProcessedEvents() {
+    processedEvents.clear();
 }
 
 // Verify the webhook from Meta
@@ -87,12 +97,33 @@ const verifyWebhookSignature = (req, res, next) => {
     return res.sendStatus(403);
 };
 
+async function enqueueDmEvent(eventId, senderId, messageText) {
+    if (!dmQueue || typeof dmQueue.add !== 'function') {
+        throw new Error('DM queue unavailable');
+    }
+
+    await dmQueue.add('process-dm', {
+        senderId: senderId,
+        message: messageText,
+        triggerKeyword: messageText.toLowerCase(),
+        eventId: eventId,
+    }, {
+        attempts: 5,
+        backoff: {
+            type: 'exponential',
+            delay: 2000
+        },
+        jobId: eventId,
+    });
+}
+
 // Handle incoming webhook events
 const handleWebhook = asyncHandler(async (req, res, next) => {
     const body = req.body || {};
 
     // Check for duplicate event using X-Event-ID header or payload-level deduplication
     const headerEventId = req.headers['x-event-id'];
+    let enqueueFailed = false;
     
     // Check if it's a page or instagram event
     if (body.object === 'instagram') {
@@ -111,40 +142,32 @@ const handleWebhook = asyncHandler(async (req, res, next) => {
                                 .update(`${senderId}:${message.mid || message.text}:${timestamp || Date.now()}`)
                                 .digest('hex');
 
-                            if (isEventAlreadyProcessed(eventId)) {
+                            if (hasProcessed(eventId)) {
                                 console.log(`[Webhook] Duplicate event ${eventId}, skipping`);
                                 continue;
                             }
 
                             console.log(`[Webhook] Received message from ${senderId}: ${message.text}`);
                             
-                            // Enqueue the message for asynchronous processing instead of synchronous execution
-                            // We set exponential backoff: 5 retries, starting with 2 seconds delay
+                            // Enqueue first; only mark processed after a successful add so Meta can retry on failure.
                             try {
-                                await dmQueue.add('process-dm', {
-                                    senderId: senderId,
-                                    message: message.text,
-                                    triggerKeyword: message.text.toLowerCase(),
-                                    eventId: eventId,
-                                }, {
-                                    attempts: 5,
-                                    backoff: {
-                                        type: 'exponential',
-                                        delay: 2000
-                                    },
-                                    jobId: eventId,
-                                });
+                                await enqueueDmEvent(eventId, senderId, message.text);
+                                markProcessed(eventId);
                             } catch (error) {
-                                console.warn(`[Webhook] DM queue unavailable, skipping async processing: ${error.message}`);
+                                enqueueFailed = true;
+                                console.warn(`[Webhook] DM queue enqueue failed: ${error.message}`);
                             }
                         }
                     }
                 }
             }
         }
+
+        if (enqueueFailed) {
+            // Ask Meta to retry; successfully enqueued events stay marked and will be skipped.
+            return res.status(503).send('SERVICE_UNAVAILABLE');
+        }
         
-        // Return a '200 OK' response to all requests immediately
-        // so Instagram doesn't think the webhook failed and resends it.
         return res.status(200).send('EVENT_RECEIVED');
     } else {
         // Return a '404 Not Found' if event is not from a supported object
@@ -155,5 +178,8 @@ const handleWebhook = asyncHandler(async (req, res, next) => {
 module.exports = {
     verifyWebhook,
     verifyWebhookSignature,
-    handleWebhook
+    handleWebhook,
+    hasProcessed,
+    markProcessed,
+    clearProcessedEvents,
 };

--- a/tests/controllers/instagramWebhook.test.js
+++ b/tests/controllers/instagramWebhook.test.js
@@ -1,0 +1,112 @@
+function createResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+    sendStatus: jest.fn(),
+  };
+}
+
+function messagingPayload({ text = "hello", mid = "mid-1", senderId = "sender-1", timestamp = 1700000000 } = {}) {
+  return {
+    object: "instagram",
+    entry: [
+      {
+        messaging: [
+          {
+            sender: { id: senderId },
+            timestamp,
+            message: { text, mid },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("instagram webhook dedup enqueue (#984)", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  function loadController(dmQueueMock) {
+    jest.resetModules();
+    jest.doMock("../../services/dmQueueService", () => ({
+      dmQueue: dmQueueMock,
+    }));
+    return require("../../controller/instagramWebhookController");
+  }
+
+  it("marks processed only after successful enqueue and returns 200", async () => {
+    const add = jest.fn().mockResolvedValue({ id: "job-1" });
+    const { handleWebhook, hasProcessed, clearProcessedEvents } = loadController({ add });
+    clearProcessedEvents();
+
+    const res = createResponse();
+    await handleWebhook(
+      { body: messagingPayload(), headers: { "x-event-id": "evt-success" } },
+      res,
+      jest.fn()
+    );
+
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(hasProcessed("evt-success")).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith("EVENT_RECEIVED");
+  });
+
+  it("does not mark processed and returns 503 when enqueue fails", async () => {
+    const add = jest.fn().mockRejectedValue(new Error("redis down"));
+    const { handleWebhook, hasProcessed, clearProcessedEvents } = loadController({ add });
+    clearProcessedEvents();
+
+    const res = createResponse();
+    await handleWebhook(
+      { body: messagingPayload(), headers: { "x-event-id": "evt-fail" } },
+      res,
+      jest.fn()
+    );
+
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(hasProcessed("evt-fail")).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.send).toHaveBeenCalledWith("SERVICE_UNAVAILABLE");
+  });
+
+  it("returns 503 when dmQueue is undefined", async () => {
+    const { handleWebhook, hasProcessed, clearProcessedEvents } = loadController(undefined);
+    clearProcessedEvents();
+
+    const res = createResponse();
+    await handleWebhook(
+      { body: messagingPayload(), headers: { "x-event-id": "evt-missing-queue" } },
+      res,
+      jest.fn()
+    );
+
+    expect(hasProcessed("evt-missing-queue")).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.send).toHaveBeenCalledWith("SERVICE_UNAVAILABLE");
+  });
+
+  it("skips already processed events on retry after a prior success", async () => {
+    const add = jest.fn().mockResolvedValue({ id: "job-1" });
+    const { handleWebhook, markProcessed, clearProcessedEvents } = loadController({ add });
+    clearProcessedEvents();
+    markProcessed("evt-dup");
+
+    const res = createResponse();
+    await handleWebhook(
+      { body: messagingPayload(), headers: { "x-event-id": "evt-dup" } },
+      res,
+      jest.fn()
+    );
+
+    expect(add).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith("EVENT_RECEIVED");
+  });
+});


### PR DESCRIPTION
## Description
Webhook dedup marked events processed before `dmQueue.add` succeeded. On enqueue failure the handler still returned 200, so Meta would not retry and the event was dropped for the dedup TTL.

## Related Issues
Fixes #984

## Type of Change
- [x] Bug fix

## Changes Made
- Split check vs mark so processed is recorded only after a successful enqueue
- Return 503 when enqueue fails (including missing `dmQueue`) so Meta can retry
- Add controller tests for success, failure, and unavailable queue cases

## Testing
- [ ] `npx jest tests/controllers/instagramWebhook.test.js`

## Checklist
- [x] Self-reviewed
- [x] Linked related issue