### PR TITLE
fix(publish): reclaim stale publishing leases

### DIFF
--- a/model/scheduledContent.js
+++ b/model/scheduledContent.js
@@ -52,11 +52,21 @@ const scheduledContentSchema = new mongoose.Schema(
         publishedBy: {
             type: String,
         },
+        publishingStartedAt: {
+            type: Date,
+            default: null,
+        },
+        publishAttempts: {
+            type: Number,
+            default: 0,
+            min: 0,
+        },
     },
     { timestamps: true }
 );
 
 scheduledContentSchema.index({ status: 1, scheduledAt: 1 });
+scheduledContentSchema.index({ status: 1, publishingStartedAt: 1 });
 
 const ScheduledContentModel =
     mongoose.models.ScheduledContent || mongoose.model("ScheduledContent", scheduledContentSchema);

--- a/tests/contentPublishWorker.test.js
+++ b/tests/contentPublishWorker.test.js
@@ -1,10 +1,13 @@
 const mongoose = require('mongoose');
-const { publishDueContent } = require('../workers/contentPublishWorker');
+const {
+    publishDueContent,
+    reclaimStalePublishingLeases,
+    PUBLISH_LEASE_MS,
+    MAX_PUBLISH_ATTEMPTS,
+} = require('../workers/contentPublishWorker');
 const ScheduledContent = require('../model/scheduledContent');
 
 describe('Content Publish Worker', () => {
-    const originalEnv = process.env.TEST_PUBLISH_FAIL;
-
     afterEach(() => {
         delete process.env.TEST_PUBLISH_FAIL;
     });
@@ -28,6 +31,8 @@ describe('Content Publish Worker', () => {
         expect(refreshed.platformPostId).toBeDefined();
         expect(typeof refreshed.platformPostId).toBe('string');
         expect(refreshed.errorMessage).toBeNull();
+        expect(refreshed.publishingStartedAt).toBeNull();
+        expect(refreshed.publishAttempts).toBe(1);
     });
 
     it('marks item as failed and records errorMessage when platform delivery fails', async () => {
@@ -90,5 +95,64 @@ describe('Content Publish Worker', () => {
 
         expect((await ScheduledContent.findById(alreadyPublished._id)).status).toBe('published');
         expect((await ScheduledContent.findById(cancelled._id)).status).toBe('cancelled');
+    });
+
+    it('reclaims stale publishing leases and republishes them', async () => {
+        const userId = new mongoose.Types.ObjectId();
+        const staleStartedAt = new Date(Date.now() - PUBLISH_LEASE_MS - 60 * 1000);
+        const stuck = await ScheduledContent.create({
+            userId,
+            caption: 'Stuck in publishing',
+            timezone: 'UTC',
+            scheduledAt: new Date(Date.now() - 5 * 60 * 1000),
+            status: 'publishing',
+            publishedBy: 'dead-worker',
+            publishingStartedAt: staleStartedAt,
+            publishAttempts: 1,
+        });
+        const fresh = await ScheduledContent.create({
+            userId,
+            caption: 'Actively publishing',
+            timezone: 'UTC',
+            scheduledAt: new Date(Date.now() - 5 * 60 * 1000),
+            status: 'publishing',
+            publishedBy: 'live-worker',
+            publishingStartedAt: new Date(),
+            publishAttempts: 1,
+        });
+
+        const publishedCount = await publishDueContent();
+        expect(publishedCount).toBe(1);
+
+        const refreshedStuck = await ScheduledContent.findById(stuck._id);
+        expect(refreshedStuck.status).toBe('published');
+        expect(refreshedStuck.publishAttempts).toBe(2);
+
+        const refreshedFresh = await ScheduledContent.findById(fresh._id);
+        expect(refreshedFresh.status).toBe('publishing');
+        expect(refreshedFresh.publishedBy).toBe('live-worker');
+    });
+
+    it('marks stale publishing as failed after max attempts', async () => {
+        const userId = new mongoose.Types.ObjectId();
+        const staleStartedAt = new Date(Date.now() - PUBLISH_LEASE_MS - 60 * 1000);
+        const exhausted = await ScheduledContent.create({
+            userId,
+            caption: 'Exhausted publishing attempts',
+            timezone: 'UTC',
+            scheduledAt: new Date(Date.now() - 5 * 60 * 1000),
+            status: 'publishing',
+            publishedBy: 'dead-worker',
+            publishingStartedAt: staleStartedAt,
+            publishAttempts: MAX_PUBLISH_ATTEMPTS,
+        });
+
+        const result = await reclaimStalePublishingLeases();
+        expect(result.failed).toBe(1);
+        expect(result.reclaimed).toBe(0);
+
+        const refreshed = await ScheduledContent.findById(exhausted._id);
+        expect(refreshed.status).toBe('failed');
+        expect(refreshed.errorMessage).toContain('Publishing lease expired');
     });
 });

--- a/workers/contentPublishWorker.js
+++ b/workers/contentPublishWorker.js
@@ -2,6 +2,8 @@ const cron = require('node-cron');
 const ScheduledContent = require('../model/scheduledContent');
 
 const INSTANCE_ID = process.env.INSTANCE_ID || `web-${process.pid}`;
+const PUBLISH_LEASE_MS = Number(process.env.PUBLISH_LEASE_MS) || 10 * 60 * 1000;
+const MAX_PUBLISH_ATTEMPTS = Number(process.env.MAX_PUBLISH_ATTEMPTS) || 3;
 
 async function publishToPlatform(item) {
     if (item.shouldFail === true || process.env.TEST_PUBLISH_FAIL === 'true') {
@@ -13,9 +15,76 @@ async function publishToPlatform(item) {
     return { postId: remoteId };
 }
 
+/**
+ * Reclaim documents stuck in `publishing` after the lease TTL expires
+ * (crashed worker, killed process, etc.). Resets to `scheduled` for another
+ * attempt, or `failed` once max attempts are exhausted.
+ * @param {Date} [now=new Date()]
+ * @returns {Promise<{ reclaimed: number, failed: number }>}
+ */
+async function reclaimStalePublishingLeases(now = new Date()) {
+    const leaseCutoff = new Date(now.getTime() - PUBLISH_LEASE_MS);
+    let reclaimed = 0;
+    let failed = 0;
+
+    while (true) {
+        const stale = await ScheduledContent.findOneAndUpdate(
+            {
+                status: 'publishing',
+                $or: [
+                    { publishingStartedAt: { $lte: leaseCutoff } },
+                    {
+                        $and: [
+                            {
+                                $or: [
+                                    { publishingStartedAt: null },
+                                    { publishingStartedAt: { $exists: false } },
+                                ],
+                            },
+                            { updatedAt: { $lte: leaseCutoff } },
+                        ],
+                    },
+                ],
+            },
+            {
+                $set: {
+                    // Temporary marker so concurrent reclaim loops do not double-pick;
+                    // immediately rewritten below based on attempt count.
+                    status: 'scheduled',
+                    publishedBy: null,
+                    publishingStartedAt: null,
+                },
+            },
+            { new: false }
+        );
+
+        if (!stale) break;
+
+        const attempts = stale.publishAttempts || 0;
+        if (attempts >= MAX_PUBLISH_ATTEMPTS) {
+            await ScheduledContent.findByIdAndUpdate(stale._id, {
+                $set: {
+                    status: 'failed',
+                    errorMessage: `Publishing lease expired after ${MAX_PUBLISH_ATTEMPTS} attempts`,
+                    publishingStartedAt: null,
+                    publishedBy: null,
+                },
+            });
+            failed++;
+        } else {
+            // Already reset to scheduled by the atomic claim above.
+            reclaimed++;
+        }
+    }
+
+    return { reclaimed, failed };
+}
+
 async function publishDueContent() {
     const now = new Date();
     let publishedCount = 0;
+
+    await reclaimStalePublishingLeases(now);
 
     // Use two-phase claim & publish to prevent duplicate delivery or false status updates
     while (true) {
@@ -28,7 +97,9 @@ async function publishDueContent() {
                 $set: {
                     status: 'publishing',
                     publishedBy: INSTANCE_ID,
+                    publishingStartedAt: now,
                 },
+                $inc: { publishAttempts: 1 },
             },
             { new: true }
         );
@@ -43,6 +114,7 @@ async function publishDueContent() {
                     publishedAt: new Date(),
                     platformPostId: publishResult.postId,
                     errorMessage: null,
+                    publishingStartedAt: null,
                 },
             });
             publishedCount++;
@@ -52,6 +124,7 @@ async function publishDueContent() {
                 $set: {
                     status: 'failed',
                     errorMessage: error.message,
+                    publishingStartedAt: null,
                 },
             });
         }
@@ -76,4 +149,11 @@ function startContentPublishWorker() {
     });
 }
 
-module.exports = { startContentPublishWorker, publishDueContent, publishToPlatform };
+module.exports = {
+    startContentPublishWorker,
+    publishDueContent,
+    publishToPlatform,
+    reclaimStalePublishingLeases,
+    PUBLISH_LEASE_MS,
+    MAX_PUBLISH_ATTEMPTS,
+};


### PR DESCRIPTION
## Description
Scheduled posts claimed into `publishing` could stay stuck forever if the worker crashed before completion. Cancel also rejected non-`scheduled` items, so creators had no recovery path.

## Related Issues
Fixes #983

## Type of Change
- [x] Bug fix

## Changes Made
- Add `publishingStartedAt` / `publishAttempts` and reclaim leases older than ~10 minutes back to `scheduled`
- Mark as `failed` after max attempts with an error message
- Cover reclaim and max-attempt paths in worker tests

## Testing
- [x] Existing publish success/failure/future/idempotency tests
- [x] Stale lease reclaim republishes
- [x] Exhausted attempts mark failed