### PR TITLE
fix(security): harden bio contactButton and background validation

### DIFF
--- a/tests/utils/bioProfileValidation.test.js
+++ b/tests/utils/bioProfileValidation.test.js
@@ -31,6 +31,7 @@ describe("bio profile payload validation", () => {
           label: "Free guide",
           url: "https://example.com/guide",
           icon: "book",
+          featured: false,
         },
       ],
     });
@@ -82,6 +83,59 @@ describe("bio profile payload validation", () => {
     })).toEqual({
       success: false,
       message: `Links must be an array of up to ${MAX_LINKS} valid HTTP or HTTPS links`,
+    });
+  });
+
+  it("rejects javascript and data contact button URLs", () => {
+    expect(validateBioProfileInput({
+      contactButton: { label: "Contact", url: "javascript:alert(1)" },
+    })).toEqual({
+      success: false,
+      message: "Contact button URL must be a valid HTTP or HTTPS URL",
+    });
+
+    expect(validateBioProfileInput({
+      contactButton: { label: "Contact", url: "data:text/html,<script>alert(1)</script>" },
+    })).toEqual({
+      success: false,
+      message: "Contact button URL must be a valid HTTP or HTTPS URL",
+    });
+  });
+
+  it("accepts http(s) contact button URLs and hex backgrounds", () => {
+    const result = validateBioProfileInput({
+      contactButton: { label: "Contact", url: "https://example.com/contact" },
+      background: "#fdf6e3",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data.contactButton).toEqual({
+      label: "Contact",
+      url: "https://example.com/contact",
+    });
+    expect(result.data.background).toBe("#fdf6e3");
+  });
+
+  it("rejects CSS injection in background", () => {
+    expect(validateBioProfileInput({
+      background: "red; } body::after { content:'Phish'",
+    })).toEqual({
+      success: false,
+      message: "Background must be a hex color (#RGB, #RRGGBB, or #RRGGBBAA)",
+    });
+
+    expect(validateBioProfileInput({
+      background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+    })).toEqual({
+      success: false,
+      message: "Background must be a hex color (#RGB, #RRGGBB, or #RRGGBBAA)",
+    });
+
+    expect(validateBioProfileInput({
+      background: "url(https://evil.example/x)",
+    })).toEqual({
+      success: false,
+      message: "Background must be a hex color (#RGB, #RRGGBB, or #RRGGBBAA)",
     });
   });
 });

--- a/utils/bioProfileValidation.js
+++ b/utils/bioProfileValidation.js
@@ -5,6 +5,7 @@ const MAX_TAGS = 10;
 const MAX_LINKS = 25;
 const VALID_THEMES = ["light", "dark", "neon", "gradient"];
 const VALID_LAYOUTS = ["list", "grid", "cards"];
+const SAFE_HEX_BACKGROUND = /^#(?:[0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
 
 const MAX_AVATAR_DATA_URL_LENGTH = 2_800_000; // ~2MB image as base64
 
@@ -16,6 +17,12 @@ function isOptionalHttpUrl(value) {
     return trimmed.length <= MAX_AVATAR_DATA_URL_LENGTH;
   }
   return isValidUrl(trimmed);
+}
+
+function isSafeBackground(value) {
+  if (value === undefined || value === null || value === "") return true;
+  if (typeof value !== "string") return false;
+  return SAFE_HEX_BACKGROUND.test(value.trim());
 }
 
 function validateHandle(handle) {
@@ -156,8 +163,16 @@ function validateBioProfileInput(body = {}) {
     };
   }
 
-  if (background !== undefined && (typeof background !== "string" || background.length > 200)) {
-    return { success: false, message: "Background must be at most 200 characters" };
+  if (background !== undefined) {
+    if (typeof background !== "string" || background.length > 200) {
+      return { success: false, message: "Background must be at most 200 characters" };
+    }
+    if (!isSafeBackground(background)) {
+      return {
+        success: false,
+        message: "Background must be a hex color (#RGB, #RRGGBB, or #RRGGBBAA)",
+      };
+    }
   }
 
   let normalizedContactButton;
@@ -171,6 +186,12 @@ function validateBioProfileInput(body = {}) {
       const url = typeof contactButton.url === "string" ? contactButton.url.trim() : "";
       if (label.length > 40 || url.length > 500) {
         return { success: false, message: "Contact button label/url too long" };
+      }
+      if (url && !isValidUrl(url)) {
+        return {
+          success: false,
+          message: "Contact button URL must be a valid HTTP or HTTPS URL",
+        };
       }
       normalizedContactButton = { label, url };
     }


### PR DESCRIPTION
## Description
Public bio profiles accepted unsafe `contactButton.url` schemes and free-form `background` CSS, enabling stored XSS and CSS injection on profile pages.

## Related Issues
Fixes #986

## Type of Change
- [x] Bug fix
- [x] Security fix

## Changes Made
- Validate contact button URLs with `isValidUrl` (http/https only)
- Allowlist background to hex colors only
- Add regression tests for dangerous schemes and CSS payloads

## Testing
- [x] `npm test -- tests/utils/bioProfileValidation.test.js`
- [ ] Save bio with `javascript:` contact URL is rejected
- [ ] Save bio with CSS metacharacters in background is rejected
- [ ] Valid hex background and https contact URL still save