### PR TITLE
fix(auth): enforce TOTP at login and Google OAuth when 2FA is enabled

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -15,14 +15,18 @@ const {
     getRemainingResetLockoutTime,
 } = require("../utils/loginAttemptManager");
 const { isEmailTransportConfigured } = require("../utils/email");
+const { verifyTotp } = require("../utils/totp");
 
 const CONTRIBUTOR_NAME = "Contributor";
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const VERIFICATION_TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
+const PENDING_2FA_TTL_MS = 5 * 60 * 1000;
 const MIN_PASSWORD_LENGTH = 8;
 const GUEST_CONTRIBUTOR_ROLE = "guest_contributor";
+const PENDING_2FA_PURPOSE = "2fa_pending";
 const GENERIC_LOGIN_ERROR = "Invalid email or password";
+const INVALID_2FA_ERROR = "Invalid authenticator code";
 const GOOGLE_AUTH_CANCELLED_ERROR = "Google sign-in was cancelled or could not be completed.";
 const VERIFICATION_UNAVAILABLE_ERROR = "Email verification is temporarily unavailable because email delivery is not configured. Please try again later or contact support.";
 
@@ -150,18 +154,75 @@ function createContributorToken(session) {
  * - CSRF attacks (sameSite strict prevents cross-origin cookie inclusion)
  * @returns {any}
  */
+function getCookieSecureFlag() {
+    const isProduction = process.env.NODE_ENV === "production";
+    return isProduction || process.env.COOKIE_SECURE_DEV === "true";
+}
+
 function setAuthCookie(res, token, { remember = false } = {}) {
     // Determine if we should enforce HTTPS-only cookies
     // In production, this is mandatory. In development, allow HTTP for localhost testing.
-    const isProduction = process.env.NODE_ENV === "production";
-    const isSecureEnvironment = isProduction || process.env.COOKIE_SECURE_DEV === "true";
-
     res.cookie("token", token, {
         httpOnly: true, // Prevents JavaScript from accessing this cookie (XSS protection)
-        secure: isSecureEnvironment, // Only transmit over HTTPS in production/secure environments
+        secure: getCookieSecureFlag(), // Only transmit over HTTPS in production/secure environments
         sameSite: "lax", // Lax allows top-level OAuth callback navigation to attach session cookie
         maxAge: remember ? THIRTY_DAYS_MS : ONE_WEEK_MS,
         path: "/", // Explicitly set path for clarity
+    });
+}
+
+function createPending2FAToken(user, { remember = false } = {}) {
+    return jwt.sign(
+        {
+            id: user.id || user._id.toString(),
+            purpose: PENDING_2FA_PURPOSE,
+            remember: !!remember,
+        },
+        process.env.JWT_SECRET,
+        { expiresIn: "5m" }
+    );
+}
+
+function setPending2FACookie(res, token) {
+    res.cookie("pending2fa", token, {
+        httpOnly: true,
+        secure: getCookieSecureFlag(),
+        sameSite: "lax",
+        maxAge: PENDING_2FA_TTL_MS,
+        path: "/",
+    });
+}
+
+function clearPending2FACookie(res) {
+    res.clearCookie("pending2fa", { path: "/" });
+}
+
+async function issueAuthenticatedSession(res, user, { remember = false, redirectTo = "/dashboard" } = {}) {
+    user.lastLoginAt = new Date();
+    await user.save();
+
+    const token = createToken(user, { remember });
+    setAuthCookie(res, token, { remember });
+    clearPending2FACookie(res);
+
+    return { token, redirectTo };
+}
+
+function respondRequires2FA(req, res, pendingToken) {
+    setPending2FACookie(res, pendingToken);
+
+    if (wantsHtml(req)) {
+        return res.status(200).render("login", {
+            error: null,
+            requires2FA: true,
+            googleAuthConfigured: isGoogleAuthConfigured(),
+        });
+    }
+
+    return res.status(200).json({
+        success: false,
+        requires2FA: true,
+        message: "Two-factor authentication required",
     });
 }
 
@@ -277,7 +338,7 @@ const signup = asyncHandler(async (req, res, next) => {
 const login = asyncHandler(async (req, res, next) => {
     const User = await getUserModel();
 
-    const { email, password, remember: rememberVal } = req.body || {};
+    const { email, password, remember: rememberVal, otp } = req.body || {};
     const remember = rememberVal === "on" || rememberVal === "true" || rememberVal === "1" || rememberVal === true || rememberVal === 1;
     const allowUnverifiedLogin = req.body?.allowUnverifiedLogin === "1" || req.body?.allowUnverifiedLogin === "true";
     const normalizedEmail = (email && typeof email === 'string') ? email.toLowerCase().trim() : "";
@@ -297,7 +358,7 @@ const login = asyncHandler(async (req, res, next) => {
 
     const DUMMY_HASH = "$2a$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUU";
 
-    const user = await User.findOne({ email: normalizedEmail });
+    const user = await User.findOne({ email: normalizedEmail }).select("+twoFactorSecret");
     if (!user) {
         await bcrypt.compare(password, DUMMY_HASH);
         await recordFailedLoginAttempt(normalizedEmail);
@@ -314,23 +375,11 @@ const login = asyncHandler(async (req, res, next) => {
 
     const isProduction = process.env.NODE_ENV === "production";
     const isTest = process.env.NODE_ENV === "test" || process.env.JEST_WORKER_ID !== undefined || process.env.USE_MOCK_DB === "true";
+    const verificationDeliveryUnavailable = !isEmailTransportConfigured();
+    const unverifiedLocal = (isProduction || isTest) && user.authProvider !== "google" && !user.isVerified;
+    const allowUnverifiedBypass = unverifiedLocal && verificationDeliveryUnavailable && allowUnverifiedLogin;
 
-    if ((isProduction || isTest) && user.authProvider !== "google" && !user.isVerified) {
-        const verificationDeliveryUnavailable = !isEmailTransportConfigured();
-
-        if (verificationDeliveryUnavailable && allowUnverifiedLogin) {
-            await clearLoginAttempts(normalizedEmail);
-
-            user.lastLoginAt = new Date();
-            await user.save();
-
-            const token = createToken(user, { remember });
-            setAuthCookie(res, token, { remember });
-
-            if (wantsHtml(req)) return res.redirect("/dashboard?login=unverified");
-            return res.status(200).json({ success: true, token, user: serializeUser(user) });
-        }
-
+    if (unverifiedLocal && !allowUnverifiedBypass) {
         if (wantsHtml(req)) {
             return res.redirect(`/resend-verification?email=${encodeURIComponent(normalizedEmail)}${verificationDeliveryUnavailable ? "&delivery=unavailable" : ""}`);
         }
@@ -347,11 +396,87 @@ const login = asyncHandler(async (req, res, next) => {
 
     await clearLoginAttempts(normalizedEmail);
 
-    user.lastLoginAt = new Date();
-    await user.save();
+    if (user.twoFactorEnabled) {
+        if (!otp) {
+            const pendingToken = createPending2FAToken(user, { remember });
+            return respondRequires2FA(req, res, pendingToken);
+        }
 
-    const token = createToken(user, { remember });
-    setAuthCookie(res, token, { remember });
+        if (!user.twoFactorSecret || !verifyTotp(user.twoFactorSecret, otp)) {
+            await recordFailedLoginAttempt(normalizedEmail);
+            if (wantsHtml(req)) {
+                return res.status(401).render("login", {
+                    error: INVALID_2FA_ERROR,
+                    requires2FA: true,
+                });
+            }
+            return res.status(401).json({ success: false, requires2FA: true, message: INVALID_2FA_ERROR });
+        }
+    }
+
+    const { token } = await issueAuthenticatedSession(res, user, { remember });
+
+    if (wantsHtml(req)) {
+        return res.redirect(allowUnverifiedBypass ? "/dashboard?login=unverified" : "/dashboard");
+    }
+    return res.status(200).json({ success: true, token, user: serializeUser(user) });
+});
+
+/**
+ * Complete login after TOTP verification using the pending 2FA cookie.
+ */
+const verifyLogin2FA = asyncHandler(async (req, res) => {
+    const User = await getUserModel();
+    const { otp } = req.body || {};
+    const pendingToken = req.cookies?.pending2fa || req.body?.pendingToken;
+
+    if (!pendingToken) {
+        if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
+        return res.status(401).json({ success: false, message: "Two-factor challenge expired. Please sign in again." });
+    }
+
+    let payload;
+    try {
+        payload = jwt.verify(pendingToken, process.env.JWT_SECRET);
+    } catch {
+        clearPending2FACookie(res);
+        if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
+        return res.status(401).json({ success: false, message: "Two-factor challenge expired. Please sign in again." });
+    }
+
+    if (payload.purpose !== PENDING_2FA_PURPOSE || !payload.id) {
+        clearPending2FACookie(res);
+        if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
+        return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
+    }
+
+    const user = await User.findById(payload.id).select("+twoFactorSecret");
+    if (!user || !user.twoFactorEnabled || !user.twoFactorSecret) {
+        clearPending2FACookie(res);
+        if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
+        return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
+    }
+
+    const normalizedEmail = user.email;
+    const isLocked = await checkIfLoginLocked(normalizedEmail);
+    if (isLocked) {
+        const remainingTime = await getRemainingLoginLockoutTime(normalizedEmail);
+        const lockoutMessage = `Account locked due to too many failed login attempts. Try again in ${Math.ceil(remainingTime / 60)} minutes.`;
+        if (wantsHtml(req)) return res.status(429).render("login", { error: lockoutMessage, requires2FA: true });
+        return res.status(429).json({ success: false, message: lockoutMessage });
+    }
+
+    if (!otp || !verifyTotp(user.twoFactorSecret, otp)) {
+        await recordFailedLoginAttempt(normalizedEmail);
+        if (wantsHtml(req)) {
+            return res.status(401).render("login", { error: INVALID_2FA_ERROR, requires2FA: true });
+        }
+        return res.status(401).json({ success: false, requires2FA: true, message: INVALID_2FA_ERROR });
+    }
+
+    await clearLoginAttempts(normalizedEmail);
+    const remember = !!payload.remember;
+    const { token } = await issueAuthenticatedSession(res, user, { remember });
 
     if (wantsHtml(req)) return res.redirect("/dashboard");
     return res.status(200).json({ success: true, token, user: serializeUser(user) });
@@ -371,9 +496,22 @@ const handleGoogleCallback = asyncHandler(async (req, res, next) => {
             return redirectWithLoginError(res, GOOGLE_AUTH_CANCELLED_ERROR);
         }
 
-        const token = createToken(req.user);
-        setAuthCookie(res, token);
+        const User = await getUserModel();
+        const user = await User.findById(req.user.id || req.user._id).select("+twoFactorSecret");
+        if (!user) {
+            return redirectWithLoginError(res, "Google sign-in failed. Please try again.");
+        }
 
+        if (user.twoFactorEnabled) {
+            const pendingToken = createPending2FAToken(user, { remember: false });
+            setPending2FACookie(res, pendingToken);
+            return res.redirect("/login?step=2fa");
+        }
+
+        await issueAuthenticatedSession(res, user, {
+            remember: false,
+            redirectTo: "/dashboard?login=google",
+        });
         return res.redirect("/dashboard?login=google");
     } catch (error) {
         console.error("Google login error:", error);
@@ -782,6 +920,7 @@ const resetPassword = asyncHandler(async (req, res) => {
 module.exports = {
     signup,
     login,
+    verifyLogin2FA,
     handleGoogleCallback,
     loginAsContributor,
     verifyEmail,

--- a/model/user.js
+++ b/model/user.js
@@ -230,8 +230,24 @@ class MockUserModel {
         return user;
     }
 
-    static async findOne(query = {}) {
-        return mockUsers.find((user) => matchesQuery(user, query)) || null;
+    static findOne(query = {}) {
+        const getUser = () => mockUsers.find((user) => matchesQuery(user, query)) || null;
+        const chain = {
+            select() {
+                return chain;
+            },
+            lean() {
+                const user = getUser();
+                return user ? { ...user } : null;
+            },
+            then(resolve, reject) {
+                return Promise.resolve(getUser()).then(resolve, reject);
+            },
+            catch(reject) {
+                return Promise.resolve(getUser()).catch(reject);
+            },
+        };
+        return chain;
     }
 
     static findById(id) {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const passport = require("passport");
 const GoogleStrategy = require("passport-google-oauth20").Strategy;
-const { signup, login, handleGoogleCallback, loginAsContributor, verifyEmail, resendVerificationEmail, requestPasswordReset, resetPassword } = require("../controller/auth");
+const { signup, login, verifyLogin2FA, handleGoogleCallback, loginAsContributor, verifyEmail, resendVerificationEmail, requestPasswordReset, resetPassword } = require("../controller/auth");
 const { signupValidator, loginValidator, contributorLoginValidator, resendVerificationValidator } = require("../middleware/validators");
 const connectDB = require("../connect");
 const { loginLimiter, signupLimiter, emailVerificationLimiter, forgotPasswordLimiter, resetPasswordLimiter } = require("../middleware/rateLimiters");
@@ -121,6 +121,7 @@ router.get("/login", redirectIfAuthenticated, (req, res) => {
         googleAuthConfigured,
         verificationUnavailable: req.query.verificationUnavailable === "1" || req.query.verificationUnavailable === "true",
         unverifiedEmail: req.query.email || null,
+        requires2FA: req.query.step === "2fa",
     });
 });
 
@@ -160,6 +161,7 @@ router.post("/signup", signupLimiter, signupValidator, signup);
  *         description: Internal server error
  */
 router.post("/login", loginLimiter, loginValidator, login);
+router.post("/login/2fa", loginLimiter, verifyLogin2FA);
 
 /**
  * @swagger

--- a/tests/controllers/login2fa.test.js
+++ b/tests/controllers/login2fa.test.js
@@ -1,0 +1,117 @@
+process.env.USE_MOCK_DB = "true";
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-jwt-secret-for-2fa";
+process.env.NODE_ENV = "test";
+
+const express = require("express");
+const cookieParser = require("cookie-parser");
+const request = require("supertest");
+const bcrypt = require("bcryptjs");
+const User = require("../../model/user");
+const { login, verifyLogin2FA } = require("../../controller/auth");
+const { generateHotp, decodeBase32 } = require("../../utils/totp");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  app.use(cookieParser());
+  app.set("view engine", "ejs");
+  app.set("views", require("path").join(__dirname, "../../view"));
+  app.post("/login", login);
+  app.post("/login/2fa", verifyLogin2FA);
+  app.use((err, req, res, next) => {
+    console.error(err);
+    res.status(500).json({ success: false, message: err.message });
+  });
+  return app;
+}
+
+describe("login 2FA enforcement (#976)", () => {
+  const secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+  const password = "SecretPass123!";
+  let app;
+
+  beforeAll(() => {
+    app = buildApp();
+  });
+
+  beforeEach(async () => {
+    await User.deleteMany({});
+    const passwordHash = await bcrypt.hash(password, 12);
+    await User.create({
+      name: "2FA User",
+      email: "twofa@example.com",
+      password: passwordHash,
+      isVerified: true,
+      authProvider: "local",
+      twoFactorEnabled: true,
+      twoFactorSecret: secret,
+    });
+  });
+
+  function currentOtp() {
+    const counter = Math.floor(Date.now() / 1000 / 30);
+    return generateHotp(decodeBase32(secret), counter);
+  }
+
+  it("does not issue a session cookie when 2FA is enabled and otp is missing", async () => {
+    const res = await request(app)
+      .post("/login")
+      .set("Accept", "application/json")
+      .send({ email: "twofa@example.com", password });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.requires2FA).toBe(true);
+    expect(res.body.success).toBe(false);
+    expect(res.body.token).toBeUndefined();
+
+    const setCookie = res.headers["set-cookie"] || [];
+    expect(setCookie.some((c) => c.startsWith("token="))).toBe(false);
+    expect(setCookie.some((c) => c.startsWith("pending2fa="))).toBe(true);
+  });
+
+  it("completes login with a valid otp via /login/2fa", async () => {
+    const challenge = await request(app)
+      .post("/login")
+      .set("Accept", "application/json")
+      .send({ email: "twofa@example.com", password });
+
+    const pendingCookie = (challenge.headers["set-cookie"] || []).find((c) =>
+      c.startsWith("pending2fa=")
+    );
+    expect(pendingCookie).toBeTruthy();
+
+    const res = await request(app)
+      .post("/login/2fa")
+      .set("Cookie", [pendingCookie.split(";")[0]])
+      .set("Accept", "application/json")
+      .send({ otp: currentOtp() });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.token).toBeTruthy();
+    const setCookie = res.headers["set-cookie"] || [];
+    expect(setCookie.some((c) => c.startsWith("token="))).toBe(true);
+  });
+
+  it("rejects an invalid otp", async () => {
+    const challenge = await request(app)
+      .post("/login")
+      .set("Accept", "application/json")
+      .send({ email: "twofa@example.com", password });
+
+    const pendingCookie = (challenge.headers["set-cookie"] || []).find((c) =>
+      c.startsWith("pending2fa=")
+    );
+
+    const res = await request(app)
+      .post("/login/2fa")
+      .set("Cookie", [pendingCookie.split(";")[0]])
+      .set("Accept", "application/json")
+      .send({ otp: "000000" });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.requires2FA).toBe(true);
+    expect(res.body.token).toBeUndefined();
+  });
+});

--- a/tests/routes/authRoutes.test.js
+++ b/tests/routes/authRoutes.test.js
@@ -10,6 +10,7 @@ jest.mock("../../controller/auth", () => ({
   signup: jest.fn(),
   login: jest.fn(),
   handleGoogleCallback: jest.fn(),
+  verifyLogin2FA: jest.fn(),
   loginAsContributor: jest.fn(),
   verifyEmail: jest.fn(),
   resendVerificationEmail: jest.fn(),

--- a/tests/routes/contributorLoginValidator.test.js
+++ b/tests/routes/contributorLoginValidator.test.js
@@ -10,6 +10,7 @@ jest.mock('../../controller/auth', () => ({
     signup: jest.fn(),
     login: jest.fn(),
     handleGoogleCallback: jest.fn(),
+  verifyLogin2FA: jest.fn(),
     loginAsContributor: jest.fn((req, res) => res.status(200).json({ success: true })),
     verifyEmail: jest.fn(),
     resendVerificationEmail: jest.fn(),

--- a/tests/routes/resetPasswordLimiter.test.js
+++ b/tests/routes/resetPasswordLimiter.test.js
@@ -13,6 +13,7 @@ jest.mock("../../controller/auth", () => ({
   signup: jest.fn(),
   login: jest.fn(),
   handleGoogleCallback: jest.fn(),
+  verifyLogin2FA: jest.fn(),
   loginAsContributor: jest.fn(),
   verifyEmail: jest.fn(),
   resendVerificationEmail: jest.fn(),

--- a/view/login.ejs
+++ b/view/login.ejs
@@ -584,6 +584,27 @@
 
                 <div class="divider">OR EMAIL</div>
 
+                <% const show2FA = typeof requires2FA !== 'undefined' && requires2FA; %>
+                <% if (show2FA) { %>
+                <form action="/login/2fa" method="POST" id="email-login-form">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <p style="margin-bottom: 1.25rem; color: var(--text-muted, #64748b); font-size: 0.95rem;">
+                        Enter the 6-digit code from your authenticator app to finish signing in.
+                    </p>
+                    <div class="form-group">
+                        <div class="label-row">
+                            <label for="login-otp">Authenticator code</label>
+                        </div>
+                        <input id="login-otp" type="text" name="otp" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" placeholder="123456" required>
+                    </div>
+                    <button type="submit" class="primary-btn" data-loading-text="Verifying...">
+                        VERIFY &amp; CONTINUE &rarr;
+                    </button>
+                </form>
+                <p class="switch-link">
+                    <a href="/login">Back to sign in</a>
+                </p>
+                <% } else { %>
                 <form action="/login" method="POST" id="email-login-form">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                     <% if (typeof verificationUnavailable !== 'undefined' && verificationUnavailable) { %>
@@ -621,6 +642,7 @@
                         SIGN IN &rarr;
                     </button>
                 </form>
+                <% } %>
 
                 <form action="/login/contributor" method="POST" id="contributor-login-form" style="margin-bottom: 2.5rem;">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">


### PR DESCRIPTION
## Description
2FA could be enabled in settings but login and Google OAuth still issued a full session with only the first factor. Login now requires a TOTP step (pending cookie + `/login/2fa`) before creating the auth cookie.

## Related Issues
Fixes #976

## Type of Change
- [x] Bug fix

## Changes Made
- After password/OAuth success, if `twoFactorEnabled`, issue a short-lived `pending2fa` cookie instead of a session
- Add `POST /login/2fa` to verify TOTP and complete login
- Update login UI for the authenticator step
- Mock `findOne().select()` for tests; add regression coverage

## Testing
- `npm test -- --testPathPatterns=login2fa`

## Checklist
- [x] Self-reviewed
- [x] Linked related issue