### PR TITLE
fix(webhook): mount Instagram webhook before CSRF middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,11 @@ const authRoutes = require("./routes/auth");
 const instagramRoutes = require("./routes/instagram");
 const billingRoute = require("./routes/billing");
 const { handleWebhook: handleBillingWebhook } = require("./controller/billing");
+const {
+  verifyWebhook,
+  verifyWebhookSignature,
+  handleWebhook: handleInstagramWebhook,
+} = require("./controller/instagramWebhookController");
 const domainRoute = require("./routes/domain");
 const sponsorRoute = require("./routes/sponsor");
 const settingsRoutes = require("./routes/settings");
@@ -120,6 +125,14 @@ app.use((req, res, next) => {
   });
   next();
 });
+// Instagram webhook must be mounted before the global CSRF middleware so Meta
+// callbacks (which carry no _csrf cookie) are verified by HMAC signature only.
+app.get("/api/instagram/webhook", verifyWebhook);
+app.post(
+  "/api/instagram/webhook",
+  verifyWebhookSignature,
+  handleInstagramWebhook,
+);
 app.use(generateCsrf);
 app.use(verifyCsrf);
 app.use(passport.initialize());

--- a/routes/instagram.js
+++ b/routes/instagram.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const { getInstagramProfile } = require('../controller/instagramController');
-const { verifyWebhook, verifyWebhookSignature, handleWebhook } = require('../controller/instagramWebhookController');
 
 const router = express.Router();
 
@@ -45,9 +44,5 @@ router.delete('/triggers/:id', protect, asyncHandler(async (req, res) => {
     if (!trigger) return res.status(404).json({ success: false, message: 'Trigger not found' });
     res.json({ success: true, message: 'Trigger deleted' });
 }));
-
-// Instagram DM Automation Webhook Endpoints
-router.get('/webhook', verifyWebhook);
-router.post('/webhook', verifyWebhookSignature, handleWebhook);
 
 module.exports = router;

--- a/tests/routes/instagramWebhookMount.test.js
+++ b/tests/routes/instagramWebhookMount.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('instagram webhook mount order', () => {
+    test('mounts the Meta webhook before the global CSRF middleware', () => {
+        const indexSource = fs.readFileSync(path.join(__dirname, '../../index.js'), 'utf8');
+
+        const webhookMountIndex = indexSource.indexOf('"/api/instagram/webhook"');
+        const csrfIndex = indexSource.indexOf('app.use(verifyCsrf)');
+
+        expect(webhookMountIndex).toBeGreaterThan(-1);
+        expect(csrfIndex).toBeGreaterThan(-1);
+        expect(webhookMountIndex).toBeLessThan(csrfIndex);
+    });
+
+    test('does not remount the webhook inside the instagram router', () => {
+        const routeSource = fs.readFileSync(path.join(__dirname, '../../routes/instagram.js'), 'utf8');
+
+        expect(routeSource).not.toContain('router.post("/webhook"');
+        expect(routeSource).not.toContain('verifyWebhookSignature');
+    });
+});


### PR DESCRIPTION
## Problem

The Instagram webhook routes (`GET/POST /api/instagram/webhook`) were mounted inside `routes/instagram.js`, which is applied **after** the global `app.use(generateCsrf)` / `app.use(verifyCsrf)` middleware in `index.js`. Meta's webhook calls carry no CSRF cookie/token — they are authenticated solely by the `X-Hub-Signature-256` HMAC — so every real webhook delivery was rejected with a CSRF error instead of reaching the handler.

## Fix

Moved the webhook mounting into `index.js`, **before** the CSRF middleware is applied. The webhook's only authentication is now the HMAC verification in `verifyWebhook`/`verifyWebhookSignature`, so Meta deliveries succeed without a CSRF token. Removed the webhook routes and imports from `routes/instagram.js`.

## Files changed

- `index.js` — mount `GET/POST /api/instagram/webhook` before `generateCsrf`/`verifyCsrf`
- `routes/instagram.js` — removed the webhook route block (no longer needed)
- `tests/routes/instagramWebhookMount.test.js` — new tests

## Testing

- New test suite `tests/routes/instagramWebhookMount.test.js` (2 tests):
  - mounts the Meta webhook before the global CSRF middleware
  - does not remount the webhook inside the instagram router
- Full suite: `7 failed / 157 passed` vs `main` baseline `7 failed / 155 passed` — no new failures.

Closes #1002
