### PR TITLE
fix(ssrf): block IPv4-mapped and bracketed IPv6 addresses

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -16,11 +16,8 @@ function parseListLimit(value) {
     return Math.min(parsed, MAX_LINK_LIST_LIMIT);
 }
 
-function isPrivateIP(ip) {
-    if (net.isIPv6(ip)) {
-        return ip === '::1' || ip === '0:0:0:0:0:0:0:1';
-    }
-    const parts = ip.split('.').map(Number);
+function isPrivateIPv4(ipv4) {
+    const parts = ipv4.split('.').map(Number);
     if (parts.length !== 4) return false;
     // 10.0.0.0/8
     if (parts[0] === 10) return true;
@@ -41,10 +38,67 @@ function isPrivateIP(ip) {
     return false;
 }
 
+function isPrivateIP(ip) {
+    if (net.isIPv4(ip)) {
+        return isPrivateIPv4(ip);
+    }
+
+    if (net.isIPv6(ip)) {
+        const lower = ip.toLowerCase();
+
+        // Loopback (::1) and unspecified (::) addresses
+        if (lower === '::1' || lower === '0:0:0:0:0:0:0:1' || lower === '::') {
+            return true;
+        }
+
+        // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1 or ::ffff:7f00:1) → check the embedded IPv4
+        if (lower.startsWith('::ffff:')) {
+            const embedded = lower.slice('::ffff:'.length);
+
+            if (/^(\d{1,3}\.){3}\d{1,3}$/.test(embedded)) {
+                return isPrivateIPv4(embedded);
+            }
+
+            // Hex-compressed form: last 32 bits as one or two 16-bit groups
+            const groups = embedded.split(':').filter(Boolean);
+            if (groups.length === 1 || groups.length === 2) {
+                const value = groups.reduce(
+                    (acc, group) => acc * 0x10000 + Number.parseInt(group, 16),
+                    0,
+                );
+                const ipv4 = [
+                    (value >>> 24) & 255,
+                    (value >>> 16) & 255,
+                    (value >>> 8) & 255,
+                    value & 255,
+                ].join('.');
+                return isPrivateIPv4(ipv4);
+            }
+            return false;
+        }
+
+        // Unique local addresses (ULA) fc00::/7
+        if (/^f[cd]/.test(lower)) return true;
+
+        // Link-local addresses fe80::/10
+        if (/^fe[89ab]/.test(lower)) return true;
+
+        return false;
+    }
+
+    return false;
+}
+
 function isSSRFBlocked(hostname) {
+    // Strip brackets from IPv6 literals (e.g. "[::ffff:7f00:1]")
+    const normalized =
+        hostname.startsWith('[') && hostname.endsWith(']')
+            ? hostname.slice(1, -1)
+            : hostname;
+
     // Block bare IP addresses in private ranges
-    if (net.isIP(hostname)) {
-        return isPrivateIP(hostname);
+    if (net.isIP(normalized)) {
+        return isPrivateIP(normalized);
     }
     return false;
 }
@@ -559,6 +613,9 @@ const handleDeleteShortURL = asyncHandler(async (req, res) => {
 });
 
 module.exports = {
+    isPrivateIP,
+    isSSRFBlocked,
+    validateURL,
     handleRenderDashboard,
     handleGenerateShortURL,
     handleGenerateShortUrlRender,

--- a/tests/controllers/ssrfGuard.test.js
+++ b/tests/controllers/ssrfGuard.test.js
@@ -1,0 +1,66 @@
+const { isPrivateIP, isSSRFBlocked, validateURL } = require('../../controller/url');
+
+describe('SSRF guard IPv6 handling', () => {
+    describe('isPrivateIP', () => {
+        it('blocks IPv4-mapped IPv6 in dotted form', () => {
+            expect(isPrivateIP('::ffff:127.0.0.1')).toBe(true);
+            expect(isPrivateIP('::ffff:10.0.0.1')).toBe(true);
+            expect(isPrivateIP('::ffff:192.168.1.1')).toBe(true);
+            expect(isPrivateIP('::ffff:169.254.169.254')).toBe(true);
+        });
+
+        it('blocks IPv4-mapped IPv6 in hex-compressed form', () => {
+            expect(isPrivateIP('::ffff:7f00:1')).toBe(true);
+            expect(isPrivateIP('::ffff:a00:1')).toBe(true);
+            expect(isPrivateIP('::ffff:0a00:0a')).toBe(true);
+        });
+
+        it('blocks other private IPv6 ranges', () => {
+            expect(isPrivateIP('fc00::1')).toBe(true);
+            expect(isPrivateIP('fd00::1')).toBe(true);
+            expect(isPrivateIP('fe80::1')).toBe(true);
+            expect(isPrivateIP('::1')).toBe(true);
+            expect(isPrivateIP('::')).toBe(true);
+        });
+
+        it('does not block public IPv4-mapped addresses', () => {
+            expect(isPrivateIP('::ffff:8.8.8.8')).toBe(false);
+            expect(isPrivateIP('::ffff:1.1.1.1')).toBe(false);
+        });
+    });
+
+    describe('isSSRFBlocked', () => {
+        it('strips brackets from IPv6 literals before checking', () => {
+            expect(isSSRFBlocked('[::ffff:127.0.0.1]')).toBe(true);
+            expect(isSSRFBlocked('[::ffff:7f00:1]')).toBe(true);
+            expect(isSSRFBlocked('[fe80::1]')).toBe(true);
+            expect(isSSRFBlocked('[fc00::1]')).toBe(true);
+            expect(isSSRFBlocked('[::1]')).toBe(true);
+        });
+
+        it('still blocks plain IPv4 private addresses', () => {
+            expect(isSSRFBlocked('127.0.0.1')).toBe(true);
+            expect(isSSRFBlocked('10.0.0.5')).toBe(true);
+            expect(isSSRFBlocked('169.254.169.254')).toBe(true);
+        });
+
+        it('allows public IPs', () => {
+            expect(isSSRFBlocked('8.8.8.8')).toBe(false);
+            expect(isSSRFBlocked('[::ffff:8.8.8.8]')).toBe(false);
+        });
+    });
+
+    describe('validateURL', () => {
+        it('rejects URLs pointing at private IPv4-mapped IPv6', async () => {
+            await expect(validateURL('http://[::ffff:127.0.0.1]:3000/')).rejects.toThrow('private or internal');
+            await expect(validateURL('http://[::ffff:7f00:1]/')).rejects.toThrow('private or internal');
+            await expect(validateURL('http://[::ffff:169.254.169.254]/')).rejects.toThrow('private or internal');
+        });
+
+        it('rejects URLs pointing at private IPv6 ranges', async () => {
+            await expect(validateURL('http://[fc00::1]/')).rejects.toThrow('private or internal');
+            await expect(validateURL('http://[fe80::1]/')).rejects.toThrow('private or internal');
+            await expect(validateURL('http://[::1]/')).rejects.toThrow('private or internal');
+        });
+    });
+});


### PR DESCRIPTION
## Problem

The SSRF guard in `controller/url.js` only recognized plain IPv4 private addresses. This left multiple IPv6 bypasses open in `isPrivateIP`/`isSSRFBlocked`:

- Bracketed IPv6 literals (e.g. `http://[::ffff:127.0.0.1]/`) were never stripped, so the hostname stayed a raw IPv6 string and private checks were skipped.
- IPv4-mapped IPv6 addresses (e.g. `::ffff:127.0.0.1` and its hex-compressed form `::ffff:7f00:1`) embed a private IPv4 but were treated as public.
- IPv6 ULA (`fc00::/7`), link-local (`fe80::/10`), unspecified (`::`) and loopback (`::1`) ranges were not blocked at all.

## Fix

Rewrote `isPrivateIP`/`isSSRFBlocked` in `controller/url.js`:

- Strip surrounding `[`/`]` brackets before classification.
- Detect IPv4-mapped IPv6 (`::ffff:x.x.x.x`) in both dotted and hex-compressed form and check the embedded IPv4 against private ranges.
- Block `fc00::/7`, `fe80::/10`, `::` and `::1`.
- Keep `net.isIP`-based classification for plain IPv4/IPv6.
- Exported both helpers for direct unit testing; `validateURL` now rejects all of the above.

## Files changed

- `controller/url.js` — hardened `isPrivateIP`/`isSSRFBlocked`, exported them
- `tests/controllers/ssrfGuard.test.js` — new regression tests

## Testing

- New test suite `tests/controllers/ssrfGuard.test.js` (9 tests): IPv4-mapped dotted/hex-compressed, private IPv6 ranges, bracket stripping, public IPs still allowed, `validateURL` rejection cases.
- `tests/controllers/url.test.js` (6 tests) passes once the `#999`/`#1000` index.js syntax fixes are combined (verified in a worktree); the parse failure on this branch is the unrelated index.js issue.
- Full suite: `7 failed / 164 passed` vs `main` baseline `7 failed / 155 passed` — no new failures (the extra 9 are the new SSRF tests).

Closes #1003
