### PR TITLE
fix(analytics): require creator platformId instead of falling back to 'me'

### DIFF
--- a/model/creator.js
+++ b/model/creator.js
@@ -56,6 +56,15 @@ links: [
             enum: ["instagram", "youtube", "twitter", "tiktok"],
             required: true,
         },
+        platformId: {
+            type: String,
+            trim: true,
+            default: "",
+        },
+        accessToken: {
+            type: String,
+            default: "",
+        },
         profileUrl: {
             type: String,
         },
@@ -79,6 +88,8 @@ class MockCreatorModel {
         this.userId = data.userId;
         this.username = data.username || "creator";
         this.platform = data.platform || "instagram";
+        this.platformId = data.platformId || "";
+        this.accessToken = data.accessToken || "";
         this.profileUrl = data.profileUrl || "";
         this.avatar = data.avatar || "";
         this.bio = data.bio || "";

--- a/tests/instagramAnalytics.test.js
+++ b/tests/instagramAnalytics.test.js
@@ -130,4 +130,9 @@ describe('Instagram Analytics API', () => {
         await expect(fetchInstagramAnalytics({ platform: 'youtube' }))
             .rejects.toThrow('Creator does not have a valid Instagram access token');
     });
+
+    it('throws a clear error when the platform ID is missing', async () => {
+        await expect(fetchInstagramAnalytics({ platform: 'instagram', accessToken: 'valid_token' }))
+            .rejects.toThrow('no Instagram platform ID');
+    });
 });

--- a/utils/instagramApi.js
+++ b/utils/instagramApi.js
@@ -59,8 +59,12 @@ const fetchInstagramAnalytics = async (creator) => {
         throw new Error('Creator does not have a valid Instagram access token or is not on the Instagram platform.');
     }
 
+    if (!creator.platformId) {
+        throw new Error('Creator has no Instagram platform ID; link an Instagram account to the creator to enable analytics.');
+    }
+
     try {
-        const platformId = creator.platformId || 'me';
+        const platformId = creator.platformId;
         const accessToken = creator.accessToken;
 
         // Always fetch profile metrics first so a media-permission failure can


### PR DESCRIPTION
## Problem

`fetchInstagramAnalytics` in `utils/instagramApi.js` used `creator.platformId || 'me'` as the Instagram API id. When a creator record had no `platformId`, it silently fell back to `'me'`, which either returned the wrong account's metrics or a confusing API error instead of a clear signal. The Creator model also had no `accessToken`/`platformId` fields to store the account binding needed for correct per-creator analytics.

## Fix

- Added `accessToken` and `platformId` (`String`, default `""`) fields to the `model/creator.js` schema and to `MockCreatorModel`.
- Hardened `fetchInstagramAnalytics` to reject with a clear error when `platformId` is missing (the existing missing-token guard is kept), instead of falling back to `'me'`.

## Files changed

- `model/creator.js` — added `accessToken`, `platformId`
- `utils/instagramApi.js` — explicit `platformId` guard in `fetchInstagramAnalytics`
- `tests/instagramAnalytics.test.js` — new regression case

## Testing

- `tests/instagramAnalytics.test.js` now has 5 passing tests, including a new one asserting a clear error when the platform id is missing (and confirming valid inputs still fetch).
- Full suite: `7 failed / 156 passed` vs `main` baseline `7 failed / 155 passed` — no new failures.

Closes #1004
