### PR TITLE
fix(worker): gate publishing behind CONTENT_PUBLISHING_ENABLED, stop fabricating post ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ INSTAGRAM_LOOKUP_COOLDOWN_SECONDS=30
 INSTAGRAM_APP_ID=your_instagram_app_id
 INSTAGRAM_APP_SECRET=your_instagram_app_secret
 
+# Required to enable the DM auto-reply feature (Instagram Messaging API).
+# When unset, DM automation fails loudly instead of pretending to send.
+
+INSTAGRAM_ACCESS_TOKEN=your_instagram_access_token
+
 # -------------------------------------------------------
 # AI Providers
 
@@ -301,6 +306,11 @@ JWT_SECRET=your_jwt_secret
 # Backend application URL
 
 APP_URL=http://localhost:3000 # Replace with your deployed URL in production
+
+# Content publishing is not implemented yet: it is gated behind this flag and
+# surfaces a "not_implemented" status until real platform adapters exist.
+
+CONTENT_PUBLISHING_ENABLED=false
 
 # Development server port
 

--- a/tests/contentPublishWorker.test.js
+++ b/tests/contentPublishWorker.test.js
@@ -4,12 +4,18 @@ const ScheduledContent = require('../model/scheduledContent');
 
 describe('Content Publish Worker', () => {
     const originalEnv = process.env.TEST_PUBLISH_FAIL;
+    const originalPublishFlag = process.env.CONTENT_PUBLISHING_ENABLED;
 
     afterEach(() => {
         delete process.env.TEST_PUBLISH_FAIL;
+        if (originalPublishFlag === undefined) {
+            delete process.env.CONTENT_PUBLISHING_ENABLED;
+        } else {
+            process.env.CONTENT_PUBLISHING_ENABLED = originalPublishFlag;
+        }
     });
 
-    it('publishes content whose scheduledAt has passed, sets status to published, and assigns platformPostId', async () => {
+    it('marks gated due content as failed with a not-implemented message instead of fabricating a postId', async () => {
         const userId = new mongoose.Types.ObjectId();
         const dueItem = await ScheduledContent.create({
             userId,
@@ -20,14 +26,34 @@ describe('Content Publish Worker', () => {
         });
 
         const publishedCount = await publishDueContent();
-        expect(publishedCount).toBe(1);
+        expect(publishedCount).toBe(0);
 
         const refreshed = await ScheduledContent.findById(dueItem._id);
-        expect(refreshed.status).toBe('published');
-        expect(refreshed.publishedAt).toBeInstanceOf(Date);
-        expect(refreshed.platformPostId).toBeDefined();
-        expect(typeof refreshed.platformPostId).toBe('string');
-        expect(refreshed.errorMessage).toBeNull();
+        expect(refreshed.status).toBe('failed');
+        expect(refreshed.errorMessage).toContain('not implemented');
+        expect(refreshed.platformPostId).toBeUndefined();
+        expect(refreshed.publishedAt).toBeUndefined();
+    });
+
+    it('marks content as failed when publishing is enabled but no adapter is configured', async () => {
+        const userId = new mongoose.Types.ObjectId();
+        const dueItem = await ScheduledContent.create({
+            userId,
+            caption: 'Due for publishing',
+            timezone: 'UTC',
+            scheduledAt: new Date(Date.now() - 60 * 1000),
+            status: 'scheduled',
+        });
+
+        process.env.CONTENT_PUBLISHING_ENABLED = 'true';
+
+        const publishedCount = await publishDueContent();
+        expect(publishedCount).toBe(0);
+
+        const refreshed = await ScheduledContent.findById(dueItem._id);
+        expect(refreshed.status).toBe('failed');
+        expect(refreshed.errorMessage).toContain('no publishing adapter');
+        expect(refreshed.platformPostId).toBeUndefined();
     });
 
     it('marks item as failed and records errorMessage when platform delivery fails', async () => {

--- a/tests/contentPublishWorker.test.js
+++ b/tests/contentPublishWorker.test.js
@@ -31,7 +31,7 @@ describe('Content Publish Worker', () => {
         const refreshed = await ScheduledContent.findById(dueItem._id);
         expect(refreshed.status).toBe('failed');
         expect(refreshed.errorMessage).toContain('not implemented');
-        expect(refreshed.platformPostId).toBeUndefined();
+        expect(refreshed.platformPostId).toBeNull();
         expect(refreshed.publishedAt).toBeUndefined();
     });
 
@@ -53,7 +53,7 @@ describe('Content Publish Worker', () => {
         const refreshed = await ScheduledContent.findById(dueItem._id);
         expect(refreshed.status).toBe('failed');
         expect(refreshed.errorMessage).toContain('no publishing adapter');
-        expect(refreshed.platformPostId).toBeUndefined();
+        expect(refreshed.platformPostId).toBeNull();
     });
 
     it('marks item as failed and records errorMessage when platform delivery fails', async () => {

--- a/workers/contentPublishWorker.js
+++ b/workers/contentPublishWorker.js
@@ -8,9 +8,14 @@ async function publishToPlatform(item) {
         throw new Error('Platform API delivery failed: Invalid authentication token or missing media payload.');
     }
 
-    const platform = item.platform || 'instagram';
-    const remoteId = `${platform}_post_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
-    return { postId: remoteId };
+    // Real platform adapters (auth token, media upload, platform API calls) are
+    // not implemented. Gate the feature behind a config flag and surface a
+    // "not_implemented" status instead of fabricating a postId.
+    if (process.env.CONTENT_PUBLISHING_ENABLED !== 'true') {
+        return { success: false, reason: 'not_implemented' };
+    }
+
+    throw new Error('Platform API delivery failed: no publishing adapter is configured.');
 }
 
 async function publishDueContent() {
@@ -37,15 +42,26 @@ async function publishDueContent() {
 
         try {
             const publishResult = await publishToPlatform(claimedItem);
-            await ScheduledContent.findByIdAndUpdate(claimedItem._id, {
-                $set: {
-                    status: 'published',
-                    publishedAt: new Date(),
-                    platformPostId: publishResult.postId,
-                    errorMessage: null,
-                },
-            });
-            publishedCount++;
+            if (publishResult.success) {
+                await ScheduledContent.findByIdAndUpdate(claimedItem._id, {
+                    $set: {
+                        status: 'published',
+                        publishedAt: new Date(),
+                        platformPostId: publishResult.postId,
+                        errorMessage: null,
+                    },
+                });
+                publishedCount++;
+            } else {
+                const errorMessage = `Content publishing not implemented: ${publishResult.reason || 'unknown'}.`;
+                console.warn(`[ContentPublishWorker] ${errorMessage}`);
+                await ScheduledContent.findByIdAndUpdate(claimedItem._id, {
+                    $set: {
+                        status: 'failed',
+                        errorMessage,
+                    },
+                });
+            }
         } catch (error) {
             console.error(`[ContentPublishWorker] Platform publish failed for item ${claimedItem._id}:`, error.message);
             await ScheduledContent.findByIdAndUpdate(claimedItem._id, {


### PR DESCRIPTION
## Problem

`publishToPlatform` in `workers/contentPublishWorker.js` claimed to publish scheduled content but actually fabricated a fake `platform_post_...` post id and reported `success: true` without ever contacting any platform. Scheduled content was silently "published" with a made-up id, and there was no way to tell the feature was not actually implemented.

## Fix

- Gated publishing behind a `CONTENT_PUBLISHING_ENABLED` flag:
  - Flag unset → `publishToPlatform` returns `{ success: false, reason: 'not_implemented' }` and `publishDueContent` marks the item `failed` with a clear "not implemented" message instead of inventing a post id.
  - Flag set but no adapter configured → throws `no publishing adapter is configured`, which is recorded as the item's error message.
- Removed the fabricated `platform_post_...` post id generation entirely — `platformPostId` is never fabricated.

## Files changed

- `workers/contentPublishWorker.js` — flag gate, no fabricated post ids
- `tests/contentPublishWorker.test.js` — updated/added assertions that `platformPostId` is never fabricated
- `README.md` — documented `CONTENT_PUBLISHING_ENABLED`

## Testing

- `tests/contentPublishWorker.test.js` (5 passing tests), including:
  - gated due content is marked `failed` with a "not implemented" message and `platformPostId` stays `null`
  - enabled-but-no-adapter is marked `failed` with a "no publishing adapter" error and no fabricated id
- Full suite: `7 failed / 156 passed` vs `main` baseline `7 failed / 155 passed` — no new failures (the 7 pre-existing failures are unrelated).

Closes #1006
