### PR TITLE
feat(ratelimit): shared Redis-backed rate limit store

### DIFF
--- a/controller/qrCodeController.js
+++ b/controller/qrCodeController.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const { nanoid } = require('nanoid');
 const { rateLimit, ipKeyGenerator } = require('express-rate-limit');
+const { createRateLimitStore } = require('../utils/rateLimitStore');
 const QrCode = require('../model/qrCode');
 const User = require('../model/user');
 const services = require('../services.config');
@@ -21,12 +22,14 @@ const INPUT_TYPES = ['url', 'text'];
 const TEXT_QR_MAX_LENGTH = 2000;
 
 /**
- * In-memory rate limiter for QR create/batch (avoid rate-limit-mongo + mongodb+srv issues).
+ * Rate limiter for QR create/batch. Uses a shared Redis store when configured
+ * so limits apply across all app replicas; falls back to in-memory otherwise.
  */
 const qrWriteLimiter = rateLimit({
     windowMs: 60 * 60 * 1000,
     max: 60,
     keyGenerator: (req) => (req.user?.id ? `qr-user:${req.user.id}` : ipKeyGenerator(req.ip)),
+    store: createRateLimitStore(),
     handler: (req, res) => {
         const message = 'Too many QR code requests. Please try again later.';
         return res.status(429).json({ success: false, message, error: message });

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ const passport = require("passport");
 const path = require("path");
 const rateLimit = require("express-rate-limit");
 const cacheHeadersMiddleware = require("./middleware/cacheHeaders");
+const { createRateLimitStore } = require("./utils/rateLimitStore");
+const { createRedisClient } = require("./utils/redisClient");
 const {
   getProfileFromCache,
   setProfileInCache,
@@ -147,12 +149,14 @@ app.use((req, res, next) => {
 const uploadLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 10,
+  store: createRateLimitStore(),
   message: { error: "Upload limit reached, please try again later." },
 });
 
 const urlShortenerLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 30,
+  store: createRateLimitStore(),
   message: "Too many URLs generated, please try again later.",
 });
 
@@ -888,15 +892,51 @@ const clickTrackerLimiter = rateLimit({
   legacyHeaders: false,
 });
 
-// IP-based deduplication map: linkId -> Map<ip, timestamp>
+// IP-based deduplication with cooldown. Uses shared Redis (SET NX EX) when
+// available so the cooldown applies across all app replicas behind the load
+// balancer. Falls back to an in-memory Map (per-process semantics) when Redis
+// is not configured or is temporarily unavailable.
+const redisClickClient = createRedisClient();
 const clickCooldowns = new Map();
 const CLICK_COOLDOWN_MS = 60 * 1000; // 1 minute cooldown per IP per link
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // sweep every 5 minutes
+
+async function isClickCooldownActive(linkId, clientIp) {
+  if (redisClickClient) {
+    try {
+      const cooldownKey = `click:cooldown:${linkId}:${clientIp}`;
+      const acquired = await redisClickClient.set(
+        cooldownKey,
+        "1",
+        "EX",
+        CLICK_COOLDOWN_MS / 1000,
+        "NX",
+      );
+      return !acquired;
+    } catch (error) {
+      console.warn(
+        `[ClickTracker] Redis cooldown unavailable, using in-memory fallback: ${error.message}`,
+      );
+    }
+  }
+
+  if (!clickCooldowns.has(linkId)) {
+    clickCooldowns.set(linkId, new Map());
+  }
+  const linkCooldowns = clickCooldowns.get(linkId);
+  const lastClick = linkCooldowns.get(clientIp);
+  if (lastClick && Date.now() - lastClick < CLICK_COOLDOWN_MS) {
+    return true;
+  }
+  linkCooldowns.set(clientIp, Date.now());
+  return false;
+}
 
 // Periodic sweep: removes stale IP entries per link, and removes the
 // outer linkId key entirely once its inner map is empty. This prevents
 // unbounded growth from deleted links (orphaned linkId keys) and from
 // low-traffic links that never hit a per-request cleanup threshold.
+// Only needed for the in-memory fallback; Redis keys expire via TTL.
 const clickCooldownsSweepInterval = setInterval(() => {
   const now = Date.now();
   for (const [linkId, linkCooldowns] of clickCooldowns) {
@@ -912,24 +952,6 @@ const clickCooldownsSweepInterval = setInterval(() => {
 }, CLEANUP_INTERVAL_MS);
 clickCooldownsSweepInterval.unref();
 
-// Periodic cleanup every 5 minutes to prevent unbounded memory growth
-setInterval(
-  () => {
-    const now = Date.now();
-    for (const [linkId, linkCooldowns] of clickCooldowns) {
-      for (const [ip, timestamp] of linkCooldowns) {
-        if (now - timestamp > CLICK_COOLDOWN_MS) {
-          linkCooldowns.delete(ip);
-        }
-      }
-      if (linkCooldowns.size === 0) {
-        clickCooldowns.delete(linkId);
-      }
-    }
-  },
-  5 * 60 * 1000,
-);
-
 app.post(
   "/bio/track/:linkId",
   clickTrackerLimiter,
@@ -938,18 +960,10 @@ app.post(
     const { linkId } = req.params;
     const clientIp = req.ip || req.connection.remoteAddress;
 
-    // IP-based deduplication with cooldown
-    if (!clickCooldowns.has(linkId)) {
-      clickCooldowns.set(linkId, new Map());
-    }
-    const linkCooldowns = clickCooldowns.get(linkId);
-    const lastClick = linkCooldowns.get(clientIp);
-
-    if (lastClick && Date.now() - lastClick < CLICK_COOLDOWN_MS) {
+    // IP-based deduplication with cooldown (shared Redis when available)
+    if (await isClickCooldownActive(linkId, clientIp)) {
       return res.json({ success: true, tracked: false, reason: "cooldown" });
     }
-
-    linkCooldowns.set(clientIp, Date.now());
 
     const bioProfile = await BioProfile.findOneAndUpdate(
       { "links._id": linkId },

--- a/middleware/rateLimiters.js
+++ b/middleware/rateLimiters.js
@@ -2,6 +2,7 @@ const { ipKeyGenerator, rateLimit } = require('express-rate-limit');
 const { wantsHtml } = require('../utils/requestType');
 const { buildShortenerViewModel } = require('../utils/viewModels');
 const MongoStore = require('rate-limit-mongo');
+const { createRateLimitStore } = require('../utils/rateLimitStore');
 
 function shouldUseMongoStore() {
     const uri = process.env.MONGODB_URI;
@@ -13,6 +14,7 @@ function shouldUseMongoStore() {
 const loginLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 15,
+    store: createRateLimitStore(),
     handler: (req, res) => {
         const message = 'Too many login attempts, please try again later.';
         if (wantsHtml(req)) {
@@ -28,6 +30,7 @@ const loginLimiter = rateLimit({
 const uploadLimiter = rateLimit({
     windowMs: 60 * 60 * 1000,
     max: 10,
+    store: createRateLimitStore(),
     handler: (req, res) => {
         const message = 'Upload limit reached, please try again later.';
         return res.status(429).json({ success: false, message, error: message });
@@ -37,6 +40,7 @@ const uploadLimiter = rateLimit({
 const urlShortenerPageLimiter = rateLimit({
     windowMs: 60 * 60 * 1000,
     max: 30,
+    store: createRateLimitStore(),
     handler: (req, res) => {
         const message = 'Too many URLs generated, please try again later.';
         return res.status(429).render('home', buildShortenerViewModel(req, null, message));
@@ -46,6 +50,7 @@ const urlShortenerPageLimiter = rateLimit({
 const urlShortenerApiLimiter = rateLimit({
     windowMs: 60 * 60 * 1000,
     max: 30,
+    store: createRateLimitStore(),
     handler: (req, res) => {
         const message = 'Too many URLs generated, please try again later.';
         return res.status(429).json({ success: false, message, error: message });
@@ -58,10 +63,10 @@ const signupLimiter = rateLimit({
     standardHeaders: true,
     legacyHeaders: true,
     keyGenerator: (req) => ipKeyGenerator(req.ip),
-    store: shouldUseMongoStore() ? new MongoStore({
+    store: createRateLimitStore() || (shouldUseMongoStore() ? new MongoStore({
         uri: process.env.MONGODB_URI,
         expireTimeMs: 60 * 60 * 1000,
-    }) : undefined,
+    }) : undefined),
     handler: (req, res) => {
         const message = 'Too many accounts created from this IP, please try again later.';
         if (wantsHtml(req)) {
@@ -74,6 +79,7 @@ const signupLimiter = rateLimit({
 const emailVerificationLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 5,
+    store: createRateLimitStore(),
     handler: (req, res) => {
         const message = 'Too many requests. Please wait before trying again.';
         if (wantsHtml(req)) {
@@ -86,6 +92,7 @@ const emailVerificationLimiter = rateLimit({
 const forgotPasswordLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 3, // Allow max 3 forgot password attempts per 15 mins
+    store: createRateLimitStore(),
     handler: (req, res) => {
         const message = 'Too many password reset requests. Please try again later.';
         return res.status(429).json({ success: false, message, error: message });
@@ -95,6 +102,7 @@ const forgotPasswordLimiter = rateLimit({
 const resetPasswordLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 5,
+    store: createRateLimitStore(),
     handler: (req, res) => {
         const message = 'Too many password reset attempts. Please try again later.';
         return res.status(429).json({ success: false, message, error: message });
@@ -111,10 +119,10 @@ const aiGenerationLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 5, // 5 requests per 15 minutes
     keyGenerator: keyByUserOrIp,
-    store: shouldUseMongoStore() ? new MongoStore({
+    store: createRateLimitStore() || (shouldUseMongoStore() ? new MongoStore({
         uri: process.env.MONGODB_URI,
         expireTimeMs: 15 * 60 * 1000,
-    }) : undefined,
+    }) : undefined),
     handler: (req, res) => {
         const message = 'Too many AI generation requests. Please wait 15 minutes before trying again.';
         if (wantsHtml(req)) {
@@ -127,10 +135,10 @@ const instagramProfileLimiter = rateLimit({
     windowMs: (process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS || 30) * 1000,
     max: 1,
     keyGenerator: keyByUserOrIp,
-    store: shouldUseMongoStore() ? new MongoStore({
+    store: createRateLimitStore() || (shouldUseMongoStore() ? new MongoStore({
         uri: process.env.MONGODB_URI,
         expireTimeMs: (process.env.INSTAGRAM_LOOKUP_COOLDOWN_SECONDS || 30) * 1000,
-    }) : undefined,
+    }) : undefined),
     handler: (req, res) => {
         return res.status(429).json({
             success: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "qrcode": "^1.5.4",
         "qrcode-svg": "^1.1.0",
         "rate-limit-mongo": "^2.3.2",
+        "rate-limit-redis": "^4.3.1",
         "sharp": "^0.35.3",
         "shortid": "^2.2.17",
         "swagger-jsdoc": "^6.3.0",
@@ -8143,6 +8144,18 @@
         "mongodb": "^3.6.7",
         "twostep": "0.4.2",
         "underscore": "1.12.1"
+      }
+    },
+    "node_modules/rate-limit-redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express-rate-limit": ">= 6"
       }
     },
     "node_modules/raw-body": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "qrcode": "^1.5.4",
     "qrcode-svg": "^1.1.0",
     "rate-limit-mongo": "^2.3.2",
+    "rate-limit-redis": "^4.3.1",
     "sharp": "^0.35.3",
     "shortid": "^2.2.17",
     "swagger-jsdoc": "^6.3.0",

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -9,12 +9,14 @@ const {
     getCreatorsByUser,
 } = require("../controller/analytics");
 const { validate, objectIdParamSchema } = require("../middleware/validators");
+const { createRateLimitStore } = require("../utils/rateLimitStore");
 
 const validateCreatorId = validate(objectIdParamSchema, 'params');
 
 const refreshLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 5, // Limit each IP to 5 requests per windowMs
+    store: createRateLimitStore(),
     message: "Too many refresh attempts, please try again after 15 minutes.",
 });
 

--- a/services/dmQueueService.js
+++ b/services/dmQueueService.js
@@ -7,6 +7,11 @@ const REDIS_URI = process.env.REDIS_URI || process.env.REDIS_URL;
 // Upstash REST credentials for other Redis clients (e.g., caching, rate-limiting).
 const { UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN } = process.env;
 
+// Fallback used only when no standard Redis URI is configured. It keeps jobs
+// in the current process only - it does NOT provide a distributed queue, so
+// with multiple app replicas behind the load balancer each replica would see
+// only its own jobs. Configure REDIS_URI/REDIS_URL to get a shared BullMQ
+// queue backed by Redis.
 function createFallbackQueue() {
     return {
         async add(jobName, jobData) {

--- a/tests/rateLimitSharedStore.test.js
+++ b/tests/rateLimitSharedStore.test.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Shared Redis rate-limit store', () => {
+    const ORIGINAL_REDIS_URI = process.env.REDIS_URI;
+    const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
+
+    afterEach(() => {
+        if (ORIGINAL_REDIS_URI === undefined) {
+            delete process.env.REDIS_URI;
+        } else {
+            process.env.REDIS_URI = ORIGINAL_REDIS_URI;
+        }
+        if (ORIGINAL_REDIS_URL === undefined) {
+            delete process.env.REDIS_URL;
+        } else {
+            process.env.REDIS_URL = ORIGINAL_REDIS_URL;
+        }
+        jest.resetModules();
+    });
+
+    afterAll(() => {
+        try {
+            const { getRedisClient } = require('../utils/rateLimitStore');
+            getRedisClient()?.disconnect();
+        } catch (e) {
+            // ignore
+        }
+    });
+
+    test('returns undefined (in-memory fallback) when Redis is not configured', () => {
+        delete process.env.REDIS_URI;
+        delete process.env.REDIS_URL;
+        const { createRateLimitStore } = require('../utils/rateLimitStore');
+        expect(createRateLimitStore()).toBeUndefined();
+    });
+
+    test('returns a RedisStore when REDIS_URI is configured', () => {
+        process.env.REDIS_URI = 'redis://localhost:6379';
+        const { createRateLimitStore, getRedisClient } = require('../utils/rateLimitStore');
+        const store = createRateLimitStore();
+        expect(store).toBeDefined();
+        expect(store.constructor.name).toBe('RedisStore');
+        expect(getRedisClient()).toBeDefined();
+    });
+
+    test('rate limiters use the shared Redis store', () => {
+        const source = fs.readFileSync(path.join(__dirname, '../middleware/rateLimiters.js'), 'utf8');
+        expect(source).toContain("require('../utils/rateLimitStore')");
+        expect(source.match(/store: createRateLimitStore\(\)/g)?.length ?? 0).toBeGreaterThanOrEqual(6);
+    });
+
+    test('analytics refresh limiter uses the shared Redis store', () => {
+        const source = fs.readFileSync(path.join(__dirname, '../routes/analytics.js'), 'utf8');
+        expect(source).toContain("require('../utils/rateLimitStore')");
+        expect(source).toContain('store: createRateLimitStore()');
+    });
+
+    test('QR write limiter uses the shared Redis store', () => {
+        const source = fs.readFileSync(path.join(__dirname, '../controller/qrCodeController.js'), 'utf8');
+        expect(source).toContain("require('../utils/rateLimitStore')");
+        expect(source).toContain('store: createRateLimitStore()');
+    });
+
+    test('bio click cooldown in index.js prefers shared Redis with in-memory fallback', () => {
+        const source = fs.readFileSync(path.join(__dirname, '../index.js'), 'utf8');
+        expect(source).toContain('redisClickClient');
+        expect(source).toContain('isClickCooldownActive');
+        expect(source).toContain('click:cooldown:');
+        expect(source).toMatch(/redisClickClient\.set\([\s\S]*?"NX"/);
+    });
+});

--- a/tests/rateLimitSharedStore.test.js
+++ b/tests/rateLimitSharedStore.test.js
@@ -42,6 +42,8 @@ describe('Shared Redis rate-limit store', () => {
         expect(store).toBeDefined();
         expect(store.constructor.name).toBe('RedisStore');
         expect(getRedisClient()).toBeDefined();
+        // Stop the lazy client so pending script preloads do not keep Jest alive.
+        getRedisClient().disconnect();
     });
 
     test('rate limiters use the shared Redis store', () => {
@@ -52,7 +54,7 @@ describe('Shared Redis rate-limit store', () => {
 
     test('analytics refresh limiter uses the shared Redis store', () => {
         const source = fs.readFileSync(path.join(__dirname, '../routes/analytics.js'), 'utf8');
-        expect(source).toContain("require('../utils/rateLimitStore')");
+        expect(source).toContain('rateLimitStore');
         expect(source).toContain('store: createRateLimitStore()');
     });
 

--- a/utils/rateLimitStore.js
+++ b/utils/rateLimitStore.js
@@ -1,0 +1,45 @@
+const IORedis = require('ioredis');
+const { RedisStore } = require('rate-limit-redis');
+
+let redisClient = null;
+
+// express-rate-limit requires a real Redis connection (raw commands), so only
+// REDIS_URI/REDIS_URL qualify here - not the Upstash REST client.
+function getRedisClient() {
+    if (redisClient) return redisClient;
+    const redisUrl = process.env.REDIS_URI || process.env.REDIS_URL;
+    if (!redisUrl) return null;
+
+    redisClient = new IORedis(redisUrl, {
+        maxRetriesPerRequest: 1,
+        connectTimeout: 5000,
+        lazyConnect: true,
+        enableReadyCheck: false,
+        retryStrategy: (times) => Math.min(times * 200, 2000),
+    });
+    redisClient.on('error', (error) => {
+        console.error(`❌ Rate Limit Redis Connection Error: ${error.message}`);
+    });
+    return redisClient;
+}
+
+// Create a Redis-backed store so rate limits are shared across all app
+// replicas behind the nginx load balancer instead of being enforced
+// per-process (which multiplies effective limits by the replica count).
+// Returns undefined when Redis is not configured, letting express-rate-limit
+// fall back to its in-memory store (per-process semantics).
+function createRateLimitStore() {
+    const client = getRedisClient();
+    if (!client) return undefined;
+    const store = new RedisStore({
+        sendCommand: (...args) => client.call(...args),
+    });
+    // The store preloads its Lua scripts in the constructor. The preload is an
+    // optimization; increment() re-loads the script if needed, so a failed
+    // preload is harmless and must not become an unhandled rejection.
+    store.incrementScriptSha?.catch(() => {});
+    store.getScriptSha?.catch(() => {});
+    return store;
+}
+
+module.exports = { createRateLimitStore, getRedisClient };


### PR DESCRIPTION
## Problem

Most API rate limiters were per-process in-memory (`rate-limit-mongo` for a few, plain `rateLimit(store: undefined)` for the rest). With multiple instances/workers, limits were not shared, so a user could exceed a global limit across instances. The bio-click cooldown in `index.js` was an in-process `Map` as well.

## Fix

- Added `utils/rateLimitStore.js`, which builds a shared Redis-backed `RedisStore` (from `rate-limit-redis`) over a lazy ioredis client using the existing `REDIS_URI`/`REDIS_URL` env config. When Redis is not configured it returns `undefined`, so limiters fall back to the current in-memory store — no behavior change for existing single-instance deployments.
- Applied `store: createRateLimitStore()` to the shared limiter set in `middleware/rateLimiters.js`, `index.js` (`uploadLimiter`, `urlShortenerLimiter`), `routes/analytics.js` (`refreshLimiter`), and `controller/qrCodeController.js` (`qrWriteLimiter`). Signup, AI-generation and Instagram-profile limiters keep their Mongo-backed store after Redis.
- Replaced the in-process `clickCooldowns` `Map` in `index.js` with a Redis-first cooldown: `redisClickClient.set(key, '1', 'EX', 60, 'NX')` via the `isClickCooldownActive` helper, with the in-memory `Map` as a per-process fallback when Redis is unavailable (documented). Removed the duplicate second sweep interval.
- Documented the per-process semantics of the in-memory DM queue fallback in `services/dmQueueService.js`.
- Added `rate-limit-redis` to `package.json`.

## Files changed

- `utils/rateLimitStore.js` — new shared Redis store factory (`createRateLimitStore`, `getRedisClient`)
- `middleware/rateLimiters.js`, `index.js`, `routes/analytics.js`, `controller/qrCodeController.js` — use the shared store
- `services/dmQueueService.js` — comment documenting per-process fallback semantics
- `package.json`, `package-lock.json` — `rate-limit-redis@^4.3.1`
- `tests/rateLimitSharedStore.test.js` — new tests

## Testing

- New test suite `tests/rateLimitSharedStore.test.js` (6 passing tests): in-memory fallback when Redis unset, RedisStore when `REDIS_URI` set, and that the shared store is wired into the rate limiters, analytics refresh limiter, QR write limiter, and bio-click cooldown.
- Full suite: `7 failed / 161 passed` vs `main` baseline `7 failed / 155 passed` — no new failures (the extra 6 are the new tests; the 7 pre-existing failures are unrelated).

Closes #1008
