### PR TITLE
fix(instagram): use req.user.id in DM-trigger routes (IDOR)

### DIFF
--- a/routes/instagram.js
+++ b/routes/instagram.js
@@ -30,7 +30,7 @@ const asyncHandler = require('../utils/asyncHandler');
 
 
 router.get('/triggers', protect, asyncHandler(async (req, res) => {
-    const triggers = await DmTrigger.find({ creatorId: req.user._id });
+    const triggers = await DmTrigger.find({ creatorId: req.user.id });
     res.json({ success: true, data: triggers });
 }));
 
@@ -41,7 +41,7 @@ router.post('/triggers', protect, asyncHandler(async (req, res) => {
 }));
 
 router.delete('/triggers/:id', protect, asyncHandler(async (req, res) => {
-    const trigger = await DmTrigger.findOneAndDelete({ _id: req.params.id, creatorId: req.user._id });
+    const trigger = await DmTrigger.findOneAndDelete({ _id: req.params.id, creatorId: req.user.id });
     if (!trigger) return res.status(404).json({ success: false, message: 'Trigger not found' });
     res.json({ success: true, message: 'Trigger deleted' });
 }));

--- a/tests/routes/instagramDmTriggerIdor.test.js
+++ b/tests/routes/instagramDmTriggerIdor.test.js
@@ -1,0 +1,73 @@
+const mongoose = require('mongoose');
+const express = require('express');
+const request = require('supertest');
+const DmTrigger = require('../../model/dmTrigger');
+
+const USER_A = new mongoose.Types.ObjectId().toString();
+const USER_B = new mongoose.Types.ObjectId().toString();
+
+const mockProtect = jest.fn((req, res, next) => {
+    req.user = { id: USER_A };
+    next();
+});
+
+jest.mock('../../middleware/auth', () => ({
+    protect: mockProtect,
+}));
+
+jest.mock('../../middleware/rateLimiters', () => ({
+    instagramProfileLimiter: (req, res, next) => next(),
+}));
+
+jest.mock('../../controller/instagramController', () => ({
+    getInstagramProfile: jest.fn(),
+}));
+
+jest.mock('../../controller/instagramWebhookController', () => ({
+    verifyWebhook: jest.fn(),
+    verifyWebhookSignature: jest.fn(),
+    handleWebhook: jest.fn(),
+}));
+
+const instagramRoutes = require('../../routes/instagram');
+
+const app = express();
+app.use(express.json());
+app.use('/api/instagram', instagramRoutes);
+
+describe('Instagram DM trigger routes', () => {
+    beforeEach(async () => {
+        await DmTrigger.deleteMany({});
+    });
+
+    it('lists only the authenticated user\'s triggers', async () => {
+        await DmTrigger.create([
+            { creatorId: USER_A, keyword: 'alpha', responseUrl: 'https://a.example' },
+            { creatorId: USER_B, keyword: 'beta', responseUrl: 'https://b.example' },
+        ]);
+
+        const res = await request(app).get('/api/instagram/triggers');
+
+        expect(res.status).toBe(200);
+        expect(res.body.data).toHaveLength(1);
+        expect(res.body.data[0].creatorId.toString()).toBe(USER_A);
+    });
+
+    it('cannot delete another user\'s trigger', async () => {
+        const other = await DmTrigger.create({ creatorId: USER_B, keyword: 'beta', responseUrl: 'https://b.example' });
+
+        const res = await request(app).delete(`/api/instagram/triggers/${other._id}`);
+
+        expect(res.status).toBe(404);
+        expect(await DmTrigger.findById(other._id)).not.toBeNull();
+    });
+
+    it('deletes the authenticated user\'s own trigger', async () => {
+        const own = await DmTrigger.create({ creatorId: USER_A, keyword: 'alpha', responseUrl: 'https://a.example' });
+
+        const res = await request(app).delete(`/api/instagram/triggers/${own._id}`);
+
+        expect(res.status).toBe(200);
+        expect(await DmTrigger.findById(own._id)).toBeNull();
+    });
+});


### PR DESCRIPTION
## Problem

The Instagram DM-trigger routes in `routes/instagram.js` (`GET /dm-triggers`, `DELETE /dm-triggers/:id`) looked the user up with `req.user._id`. The JWT issued by the app only carries `id` (the create-trigger route already uses `req.user.id`), so `req.user._id` is `undefined`. As a result the routes could not match the trigger to the authenticated user — the authenticated user's own triggers would not list, and deletion of another user's trigger was not reliably prevented (IDOR).

## Fix

Changed both lookups to use `req.user.id`, matching the JWT payload shape and the pattern already used by the create-trigger route. With a valid user id, the list route scopes to the authenticated user and the delete route verifies ownership before deleting.

## Files changed

- `routes/instagram.js` — `req.user._id` → `req.user.id` in the DM-trigger list and delete routes
- `tests/routes/instagramDmTriggerIdor.test.js` — new regression tests

## Testing

- New test suite `tests/routes/instagramDmTriggerIdor.test.js` (3 tests, in-memory MongoDB, mocked auth + rate limiters + controllers):
  - lists only the authenticated user's triggers
  - cannot delete another user's trigger
  - deletes the authenticated user's own trigger
- Full suite: `7 failed / 158 passed` vs `main` baseline `7 failed / 155 passed` — no new failures (the 7 pre-existing failures are unrelated, mostly index.js parse errors from `#999`/`#1000`).

Closes #1001
