### PR TITLE
docs: remove duplicate FAQ entry already covered by Run Locally section

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,19 +380,6 @@ git checkout -b feature/your-feature-name
 
 Ensure you are using a supported Node.js version and remove `node_modules` before reinstalling dependencies.
 
-### How do I start the project locally?
-
-```bash
-npm run dev
-```
-
-Then open:
-
-```text
-http://localhost:3000
-```
-
-
 ## 📁 Project Structure
 
 ```


### PR DESCRIPTION
## 📝 Description
Removed a duplicate FAQ entry in README.md — "How do I start the project locally?" repeated the same command and URL already documented under the "Run Locally" section earlier in the file.

## 🔗 Related Issues
Fixes #None (just a documentation quick fix )

## 📋 Type of Change
- [x] 📚 Documentation update

## 🔄 Changes Made
- Removed the duplicate "How do I start the project locally?" FAQ entry
- Kept the original "Run Locally" section as the single source of truth for this info

## ✅ Testing
### How to Test
1. Open README.md
2. Confirm the run instructions still appear once, under "Run Locally"
3. Confirm no content was lost

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
N/A — documentation-only fix.

## 🚀 Deployment Notes
None.

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Simple documentation cleanup, no functional changes.

---
**Thank you for contributing to CreatorOS!** 🙌