### PR TITLE
fix(security): enforce HTTP/HTTPS URLs in URL-shortener API

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -175,6 +175,10 @@ async function handleGenerateShortURL(req, res) {
     const { redirectUrl: redirectUrlField, url, title, customSlug, tag } = req.body;
     const redirectUrl = redirectUrlField || url;
 
+    if (!redirectUrl || !isValidUrl(redirectUrl)) {
+        return res.status(400).json({ error: 'A valid HTTP or HTTPS URL is required' });
+    }
+
     let shortId = shortid();
     if (customSlug) {
         const slug = String(customSlug).trim().toLowerCase();


### PR DESCRIPTION
## Problem

The URL-shortening API accepted redirect targets with dangerous schemes (`javascript:`, `data:`, `ftp:`, `file://`) because zod's `.url()` is scheme-agnostic (RFC 3986 URI validation) and `handleGenerateShortURL` never re-validated with `isValidUrl`/`validateURL`. The strict HTTP(S) check was only applied on the HTML render path (`handleGenerateShortUrlRender`), so the two entry points disagreed. Stored targets were later served via `res.redirect()` on the public `/u/:shortId` and `/q/:shortId` routes.

## Fix

Reuse the existing `isValidUrl` helper (already imported in `controller/url.js`) at the top of `handleGenerateShortURL`. It enforces `http:`/`https:` only, rejecting `javascript:`, `data:`, `ftp:`, and `file://` targets with a clean 400 and the same message used by the schema and the HTML path.

## Files changed

- `controller/url.js` — reject non-HTTP(S) URLs in `handleGenerateShortURL` with a 400 before any lookup/creation.

## Testing

- Verified with the mock DB that `javascript:`, `data:`, `ftp:`, `file://`, empty, and missing inputs all return `400 A valid HTTP or HTTPS URL is required`, while valid `http:`/`https:` URLs still create links (201).
- `npx jest tests/controllers/urlList.test.js` passes.


Closes #1030
