### PR TITLE
fix(security): neutralize CSV formula injection in analytics export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1218,7 +1218,17 @@ app.get('/api/analytics/export', protect, asyncHandler(async (req, res) => {
                 new Date(v.timestamp).toISOString(), v.device || '', v.browser || '', v.referrer || '', v.country || '']);
         });
     });
-    const csv = rows.map(r => r.map(c => `"${String(c).replace(/"/g, '""')}"`).join(',')).join('\n');
+    // Neutralize spreadsheet formula injection: prefix cells that start with
+    // a formula-leading character (=, +, -, @, tab, CR) so Excel/LibreOffice
+    // treat them as text instead of evaluating them as formulas.
+    const csvSafeCell = (cell) => {
+        let str = String(cell ?? '');
+        if (/^[=+\-@\t\r]/.test(str)) {
+            str = `'${str}`;
+        }
+        return `"${str.replace(/"/g, '""')}"`;
+    };
+    const csv = rows.map(r => r.map(csvSafeCell).join(',')).join('\n');
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader('Content-Disposition', 'attachment; filename="analytics-export.csv"');
     res.send(csv);


### PR DESCRIPTION
## Problem

`GET /api/analytics/export` built a CSV with cells quoted by `"` but never neutralized formula-leading characters (`=`, `+`, `-`, `@`). Because the `referrer` cell is populated from the raw `Referer` HTTP header of the public redirect route, any visitor could plant an Excel/LibreOffice formula injection (DDE / `=HYPERLINK(...)` / `@SUM(...)`) into the link owner's export. The same applied to `redirectUrl` (user-controlled at creation).

## Fix

Neutralize every CSV cell before writing it: if a cell starts with a formula-leading character (`=`, `+`, `-`, `@`, tab, CR), prefix it with a single apostrophe so spreadsheets treat it as text instead of evaluating it as a formula. Double quotes are still escaped as `""` to preserve CSV quoting.

## Files changed

- `index.js` — replace the raw CSV builder in `GET /api/analytics/export` with a `csvSafeCell` sanitizer.

## Testing

- Verified the neutralization logic: cells like `=HYPERLINK("http://evil")`, `=cmd|' /C calc'!A0`, `-2+3`, and `@SUM(A1:A9)` are emitted with a leading `'`, while normal values are unchanged.
- `node --check` passes on the modified entrypoint.


Closes #1031
