### PR TITLE
fix(security): enforce strict ownership for null-userId short links

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -508,7 +508,7 @@ const handleGetAnalytics = asyncHandler(async (req, res) => {
         return res.status(404).json({ success: false, message: "Short URL not found", error: "Short URL not found" });
     }
 
-    if (entry.userId && entry.userId?.toString() !== req.user?.id) {
+    if (entry.userId?.toString() !== req.user?.id) {
         return res.status(403).json({ success: false, message: "Unauthorized to view these analytics", error: "Unauthorized to view these analytics" });
     }
 
@@ -542,7 +542,7 @@ const handleDeleteShortURL = asyncHandler(async (req, res) => {
         return res.status(404).json({ success: false, message: "Short URL not found", error: "Short URL not found" });
     }
 
-    if (entry.userId && entry.userId?.toString() !== req.user?.id) {
+    if (entry.userId?.toString() !== req.user?.id) {
         return res.status(403).json({ success: false, message: "Unauthorized to delete this URL", error: "Unauthorized to delete this URL" });
     }
 


### PR DESCRIPTION
## Problem

The ownership checks on the analytics and delete endpoints used a permissive `entry.userId && entry.userId?.toString() !== req.user?.id` condition, so any short link whose `userId` was null/missing could be read and deleted by **any** authenticated user. Every other endpoint (QR get/download/update) uses the strict `entry.userId?.toString() !== req.user?.id` form, which denies null-owned links to everyone.

## Fix

Use the strict ownership form in `handleGetAnalytics` and `handleDeleteShortURL`, matching the QR endpoints. Any link not owned by the caller (including links with `userId: null`) now returns 403.

## Files changed

- `controller/url.js` — strict ownership check in `handleGetAnalytics` and `handleDeleteShortURL`.

## Testing

- Verified with the mock DB: a `userId: null` link accessed by an authenticated user returns 403 for both `GET /api/urls/analytics/<shortId>` and `DELETE /api/urls/<shortId>`; an owned link still succeeds.


Closes #1032
