### PR TITLE
fix(security): HTML-escape title and message in smart notification emails

### DIFF
--- a/services/smartNotificationService.js
+++ b/services/smartNotificationService.js
@@ -4,6 +4,21 @@ const User = require("../model/user");
 const { isEmailTransportConfigured, createTransporter } = require("../utils/email");
 
 /**
+ * Escape a string for safe inclusion in an HTML email body.
+ * @param {String} str
+ * @returns {String}
+ */
+function escapeHtml(str) {
+    if (typeof str !== "string") return "";
+    return str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+/**
  * Get or create default notification preferences for a user.
  * @param {String|ObjectId} userId
  * @returns {Promise<Document>}
@@ -233,8 +248,8 @@ async function sendNotification(userId, payload) {
                             subject: `[CreatorOS] ${title}`,
                             text: message,
                             html: `<div style="font-family:sans-serif; padding:20px;">
-                              <h2 style="color:#2563eb;">${title}</h2>
-                              <p>${message}</p>
+                              <h2 style="color:#2563eb;">${escapeHtml(title)}</h2>
+                              <p>${escapeHtml(message)}</p>
                               <hr style="border:none; border-top:1px solid #e5e7eb; margin:20px 0;" />
                               <small style="color:#6b7280;">Sent via CreatorOS Smart Notifications</small>
                             </div>`,


### PR DESCRIPTION
## Problem

`POST /api/notifications/create` accepted arbitrary `title`/`message` strings from the request body and interpolated them into the HTML email template without any escaping. An authenticated user could inject arbitrary HTML (including script/`onerror` payloads) into notification emails, and the same unescaped payload was persisted and rendered elsewhere.

## Fix

Add an `escapeHtml` helper (matching the existing pattern in `utils/email.js`) and use it to escape `title` and `message` before embedding them in the email HTML body. `&`, `<`, `>`, `"`, and `'` are converted to their HTML entities so user input is always rendered as text.

## Files changed

- `services/smartNotificationService.js` — add `escapeHtml` helper and apply it to `title`/`message` in the email template.

## Testing

- Added a temporary jest verification (since removed) mocking `utils/email`: a payload of `<img src=x onerror=alert(1)>` / `<script>alert("x")</script>` is emitted in the email HTML as `&lt;img ...&gt;` and `&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;`, with no raw markup present.
- `npx jest tests/services/smartNotificationService.test.js` passes (13/13).


Closes #1033
