### PR TITLE
fix(notifications): report push and SMS channels as unavailable instead of fake success

### DIFF
--- a/model/notification.js
+++ b/model/notification.js
@@ -69,7 +69,7 @@ const notificationSchema = new mongoose.Schema(
         deliveryLogs: [
             {
                 channel: { type: String, enum: ["in_app", "email", "sms", "push"] },
-                status: { type: String, enum: ["success", "failed", "delayed", "skipped"] },
+                status: { type: String, enum: ["success", "failed", "delayed", "skipped", "unavailable"] },
                 timestamp: { type: Date, default: Date.now },
                 error: { type: String },
             },

--- a/services/smartNotificationService.js
+++ b/services/smartNotificationService.js
@@ -247,11 +247,13 @@ async function sendNotification(userId, payload) {
                     deliveryLogs.push({ channel: "email", status: "failed", error: err.message });
                 }
             } else if (channel === "push") {
-                // Multi-channel Push Notification Handler simulator
-                deliveryLogs.push({ channel: "push", status: "success" });
+                // Push delivery is not implemented yet; report honestly
+                // instead of claiming a fake success.
+                deliveryLogs.push({ channel: "push", status: "unavailable", error: "Push notifications are not currently supported" });
             } else if (channel === "sms") {
-                // Multi-channel SMS Delivery Handler simulator
-                deliveryLogs.push({ channel: "sms", status: "success" });
+                // SMS delivery is not implemented yet; report honestly
+                // instead of claiming a fake success.
+                deliveryLogs.push({ channel: "sms", status: "unavailable", error: "SMS notifications are not currently supported" });
             }
         }
     } else {


### PR DESCRIPTION
## Problem

The "push" and "sms" notification channels were stubs: `sendNotification` recorded `status: "success"` in the delivery log without ever sending anything. Users who enabled push or SMS channels were told delivery "succeeded" and the channel analytics counted these as delivered — a silent, misleading feature failure.

## Fix

- `services/smartNotificationService.js`: push and SMS deliveries now record `status: "unavailable"` with an explanatory error instead of a fake `success`. The delivery log and analytics now reflect reality.
- `model/notification.js`: add `"unavailable"` to the `deliveryLogs.status` enum so the honest status can be persisted.

## Files changed

- `services/smartNotificationService.js` — replace simulated success for `push`/`sms` with `unavailable` + error message.
- `model/notification.js` — allow `unavailable` in the `deliveryLogs.status` enum.

## Testing

- Verified via jest: sending to `channels: ['push', 'sms']` (with both enabled in preferences) produces `deliveryLogs` of `[{channel: "push", status: "unavailable"}, {channel: "sms", status: "unavailable"}]` and no `success` entries.
- `npx jest tests/services/smartNotificationService.test.js tests/controllers/smartNotificationController.test.js tests/models/notificationModel.test.js` passes (25/25).


Closes #1034
