### PR TITLE
fix(notifications,url): validate and clamp pagination limit and page params

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -296,7 +296,7 @@ const generateBase64QR = async (text, fg, bg) => {
 const handleRenderDashboard = asyncHandler(async (req, res) => {
     // Implement cursor-based pagination for performance
     // Prevent loading entire collection into memory on large datasets
-    const pageSize = Math.min(parseInt(req.query.limit, 10) || 20, 100); // Max 100 per page
+    const pageSize = parseListLimit(req.query.limit); // Max 100 per page, defaults to 20
     const cursor = req.query.cursor;
 
     if (cursor && !mongoose.Types.ObjectId.isValid(cursor)) {

--- a/services/smartNotificationService.js
+++ b/services/smartNotificationService.js
@@ -325,8 +325,9 @@ async function getNotificationHistory(userId, options = {}) {
         ];
     }
 
-    const skip = (Math.max(1, parseInt(page, 10)) - 1) * parseInt(limit);
-    const limitNum = parseInt(limit);
+    const pageNum = Math.max(1, Number.parseInt(page, 10) || 1);
+    const limitNum = Math.min(Math.max(1, Number.parseInt(limit, 10) || 20), 100);
+    const skip = (pageNum - 1) * limitNum;
 
     const [notifications, total, unreadCount] = await Promise.all([
         Notification.find(query)
@@ -344,7 +345,7 @@ async function getNotificationHistory(userId, options = {}) {
     return {
         notifications,
         total,
-        page: parseInt(page),
+        page: pageNum,
         totalPages: Math.ceil(total / limitNum) || 1,
         unreadCount,
     };


### PR DESCRIPTION
## Problem

Pagination parameters were not validated, which allowed malformed values to break behavior:

- `GET /api/notifications/history` used raw `parseInt` on `limit`/`page`. A non-numeric or negative `limit` produced `NaN`/negative values in `skip` and `limit`, causing `skip` + `limit` to be `NaN` (Mongoose coerces to `0`, silently returning the wrong page) and `Math.ceil(total / NaN)` → `NaN` in `totalPages`. A negative `page` could also produce negative `skip`.
- The dashboard (`handleRenderDashboard`) computed `pageSize` inline with `parseInt` + manual clamp, duplicating logic and leaving edge cases inconsistent.

## Fix

- `services/smartNotificationService.js` (`getNotificationHistory`): validate and clamp `page` (min 1) and `limit` (default 20, min 1, max 100) into `pageNum`/`limitNum`, compute `skip` from the validated values, and return `page: pageNum` instead of the raw input.
- `controller/url.js` (`handleRenderDashboard`): reuse the existing `parseListLimit` helper (positive-int, clamps to 100) instead of the inline `parseInt` expression, keeping behavior consistent with `handleListUserLinks`.

## Files changed

- `services/smartNotificationService.js` — clamp/validate `page` and `limit` in `getNotificationHistory`.
- `controller/url.js` — use `parseListLimit` for the dashboard page size.

## Testing

- Temp jest tests (removed before commit) verified: dashboard `limit=-5` and `limit=abc` coerce to the 20 default, `limit=500` clamps to 100; notification history with `limit='abc', page='xyz'` returns page 1 with correct `total`/`totalPages` and no `NaN`.
- `npx jest tests/controllers/urlList.test.js tests/services/smartNotificationService.test.js` passes (15/15).
- `tests/controllers/dashboardCursor.test.js` fails only due to the pre-existing #1029 (missing `mongoose` import on `main`); verified it passes when both changes are applied together.


Closes #1035
