### PR TITLE
fix(billing): rate limit checkout creation and make sessions idempotent

### DIFF
--- a/controller/billing.js
+++ b/controller/billing.js
@@ -28,6 +28,10 @@ const createCheckoutSession = asyncHandler(async (req, res) => {
 
     const user = req.user;
 
+    // Derive a deterministic idempotency key so repeated identical requests
+    // reuse the same checkout session instead of creating duplicates.
+    const idempotencyKey = `checkout:${user.id}:${resolvedPriceId}`;
+
     try {
         const session = await stripe.checkout.sessions.create({
             payment_method_types: ["card"],
@@ -42,7 +46,7 @@ const createCheckoutSession = asyncHandler(async (req, res) => {
             cancel_url: `${process.env.BASE_URL}/dashboard?checkout=cancelled`,
             customer_email: user.email,
             client_reference_id: user.id,
-        });
+        }, { idempotencyKey });
 
         res.json({ success: true, url: session.url });
     } catch (error) {

--- a/middleware/rateLimiters.js
+++ b/middleware/rateLimiters.js
@@ -142,6 +142,20 @@ const instagramProfileLimiter = rateLimit({
     }
 });
 
+const billingCheckoutLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 5, // 5 checkout session creations per 15 minutes per user
+    keyGenerator: keyByUserOrIp,
+    store: shouldUseMongoStore() ? new MongoStore({
+        uri: process.env.MONGODB_URI,
+        expireTimeMs: 15 * 60 * 1000,
+    }) : undefined,
+    handler: (req, res) => {
+        const message = 'Too many checkout requests. Please try again later.';
+        return res.status(429).json({ success: false, message, error: message });
+    }
+});
+
 module.exports = {
     loginLimiter,
     uploadLimiter,
@@ -151,6 +165,7 @@ module.exports = {
     emailVerificationLimiter,
     aiGenerationLimiter,
     instagramProfileLimiter,
+    billingCheckoutLimiter,
     forgotPasswordLimiter,
     resetPasswordLimiter
 };

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const { createCheckoutSession } = require("../controller/billing");
 const { protect } = require("../middleware/auth");
+const { billingCheckoutLimiter } = require("../middleware/rateLimiters");
 
 const router = express.Router();
 
@@ -17,7 +18,9 @@ const router = express.Router();
  *         description: Checkout session created successfully
  *       401:
  *         description: Unauthorized
+ *       429:
+ *         description: Too many requests
  */
-router.post("/checkout", protect, createCheckoutSession);
+router.post("/checkout", protect, billingCheckoutLimiter, createCheckoutSession);
 
 module.exports = router;

--- a/tests/controllers/billingCheckoutPrice.test.js
+++ b/tests/controllers/billingCheckoutPrice.test.js
@@ -67,7 +67,7 @@ describe('createCheckoutSession price validation', () => {
                     quantity: 1,
                 },
             ],
-        }));
+        }), expect.objectContaining({ idempotencyKey: 'checkout:user-1:price_allowed' }));
         expect(res.json).toHaveBeenCalledWith({ success: true, url: 'https://checkout.test/session' });
     });
 });


### PR DESCRIPTION
## Problem

`POST /api/billing/checkout` had no protection against abuse or accidental duplication:

- No rate limiting: a user (or an abuser with a token) could hit the endpoint in a tight loop, creating a Stripe session each time.
- No idempotency: repeated clicks / retries of the same checkout request each called `stripe.checkout.sessions.create`, producing multiple distinct sessions and surfacing multiple checkout URLs.

## Fix

- `middleware/rateLimiters.js`: add `billingCheckoutLimiter` (max 5 requests per 15 minutes per user, using the existing `keyByUserOrIp` key generator and optional MongoStore, mirroring the other limiters) returning `429` JSON.
- `routes/billing.js`: mount `billingCheckoutLimiter` on `POST /api/billing/checkout` between `protect` and the handler.
- `controller/billing.js`: derive a deterministic Stripe idempotency key (`checkout:{userId}:{priceId}`) and pass it as the SDK options object, so repeated identical requests reuse the same checkout session instead of creating duplicates.

## Files changed

- `middleware/rateLimiters.js` — new `billingCheckoutLimiter` (added to exports).
- `routes/billing.js` — apply the limiter to the checkout route; document `429` in the Swagger block.
- `controller/billing.js` — pass `{ idempotencyKey }` to `stripe.checkout.sessions.create`.
- `tests/controllers/billingCheckoutPrice.test.js` — assert the idempotency key is passed to the SDK (reflects the new behavior).

## Testing

- `npx jest tests/controllers/billingCheckoutPrice.test.js` passes — verifies the idempotency key is passed per user+plan and price validation still rejects unapproved `priceId`s.
- Temp test (removed before commit) verified `billingCheckoutLimiter` is exported and the controller passes `{ idempotencyKey: 'checkout:user-1:price_allowed' }`.
- Note: `tests/routes/billingWebhookMount.test.js` fails on `main` as well (it searches for single-quoted `app.post('/api/billing/webhook', express.raw` while `index.js` uses multi-line/double-quoted formatting) — unrelated to this change.


Closes #1036
