### PR TITLE
fix(url): fall back to createdAt for linkedAt so links show their real creation date

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -143,7 +143,7 @@ function formatClicks(count) {
  * @returns {any}
  */
 function serializeLink(entry, hostBase) {
-    const linkedAt = entry.linkedAt || entry.createdAt?.[0]?.timeStamp || new Date();
+    const linkedAt = entry.linkedAt || entry.createdAt || new Date();
     return {
         shortId: entry.shortId,
         redirectUrl: entry.redirectUrl,


### PR DESCRIPTION
## Problem

`serializeLink` computed the display date as:

```js
const linkedAt = entry.linkedAt || entry.createdAt?.[0]?.timeStamp || new Date();
```

`createdAt` on a URL document is a plain `Date` (`model/url.js`), not an array of `{ timeStamp }` objects, so `entry.createdAt?.[0]?.timeStamp` is always `undefined`. For links created without an explicit `linkedAt` (e.g. the QR-generation handler at `controller/url.js:369`, and any legacy rows), the expression fell through to `new Date()` — every such link showed today's date instead of the day it was actually created.

## Fix

- `controller/url.js` (`serializeLink`): fall back to the document's real `createdAt` (a valid `Date`) instead of the never-matching `createdAt?.[0]?.timeStamp`, keeping `new Date()` only as a last resort.

## Files changed

- `controller/url.js` — corrected the `linkedAt` fallback chain.

## Testing

- Temp jest tests (removed before commit, mock DB) verified:
  - A link with only `createdAt` (no `linkedAt`) serializes `linkedAt`/`linkedAtLabel` from `createdAt` (e.g. `Mar 15, 2024`), not the current date.
  - An explicit `linkedAt` still takes precedence over `createdAt`.
- `npx jest tests/controllers/urlList.test.js tests/dashboard.test.js tests/models/url.test.js` passes (5/5).


Closes #1037
