### PR TITLE
fix(vault): persist uploaded files instead of deleting them (#381)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ coverage/
 # MongoDB
 *.mongodb
 *.db
+
+# Vault file uploads (persisted user files — not committed)
+uploads/

--- a/index.js
+++ b/index.js
@@ -153,11 +153,7 @@ app.set("view engine", "ejs");
 app.set("views", path.join(__dirname, "view"));
 app.locals.BRAND = BRAND;
 
-const uploadLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000,
-  max: 10,
-  message: { error: "Upload limit reached, please try again later." },
-});
+
 
 const urlShortenerLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
@@ -176,7 +172,6 @@ const {
 const fs = require("fs");
 app.use(express.static(path.join(__dirname, "public")));
 const shortid = require("shortid");
-const multer = require("multer");
 const services = require("./services.config");
 const User = require("./model/user");
 const Creator = require("./model/creator");
@@ -231,99 +226,7 @@ app.use(
   }),
 );
 
-const os = require("os");
-const uploadDir = os.tmpdir();
 
-const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
-    cb(null, uploadDir);
-  },
-  filename: function (req, file, cb) {
-    let sanitizedFilename = path.basename(file.originalname);
-    sanitizedFilename = sanitizedFilename
-      .replace(/[/\\?%*:|"<>]/g, "-")
-      .replace(/^\.+/, "");
-    cb(null, Date.now() + "-" + sanitizedFilename);
-  },
-});
-
-const fileFilter = (req, file, cb) => {
-  const ALLOWED_MIME_TYPES = [
-    "image/jpeg",
-    "image/png",
-    "image/webp",
-    "image/gif",
-  ];
-  const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
-
-  const fileExtension = path.extname(file.originalname).toLowerCase();
-
-  if (
-    !ALLOWED_MIME_TYPES.includes(file.mimetype) ||
-    !ALLOWED_EXTENSIONS.includes(fileExtension)
-  ) {
-    return cb(
-      new Error("Only image files (JPEG, PNG, WebP, GIF) are allowed."),
-      false,
-    );
-  }
-
-  cb(null, true);
-};
-
-const upload = multer({
-  storage: storage,
-  limits: { fileSize: 50 * 1024 * 1024 },
-  fileFilter: fileFilter,
-});
-
-const sharp = require('sharp');
-
-async function compressImage(filePath, mimetype) {
-    // GIFs are skipped — sharp's default pipeline doesn't preserve animation
-    if (mimetype === 'image/gif') {
-        return { compressed: false };
-    }
-
-    const tempOutputPath = filePath + '.compressed';
-    const originalStats = fs.statSync(filePath);
-
-    try {
-        const pipeline = sharp(filePath).resize({
-            width: 1920,
-            height: 1920,
-            fit: 'inside',
-            withoutEnlargement: true,
-        });
-
-        if (mimetype === 'image/jpeg') {
-            pipeline.jpeg({ quality: 80 });
-        } else if (mimetype === 'image/png') {
-            pipeline.png({ quality: 80, compressionLevel: 8 });
-        } else if (mimetype === 'image/webp') {
-            pipeline.webp({ quality: 80 });
-        }
-
-        await pipeline.toFile(tempOutputPath);
-
-        const compressedStats = fs.statSync(tempOutputPath);
-
-        // Only keep the compressed version if it's actually smaller
-        if (compressedStats.size < originalStats.size) {
-            fs.renameSync(tempOutputPath, filePath);
-            return { compressed: true, originalSize: originalStats.size, newSize: compressedStats.size };
-        } else {
-            fs.unlinkSync(tempOutputPath);
-            return { compressed: false, originalSize: originalStats.size, newSize: originalStats.size };
-        }
-    } catch (err) {
-        console.error('[compress] Failed to compress image:', err);
-        if (fs.existsSync(tempOutputPath)) {
-            fs.unlinkSync(tempOutputPath);
-        }
-        return { compressed: false, originalSize: originalStats.size, newSize: originalStats.size };
-    }
-}
 
 // ── HELPERS ──────────────────────────────────────────────────────────────────
 
@@ -1126,43 +1029,13 @@ const { handleGenerateShortUrlRender } = require('./controller/url');
 const { handleQrRedirect } = require('./controller/qrCodeController');
 app.post('/services/url-shortener/shorten', protect, preventContributorWrites, urlShortenerLimiter, handleGenerateShortUrlRender);
 
-// ── FILE UPLOAD POST ──
-
-app.post(
-  "/services/file-upload/upload",
+// ── FILE UPLOAD (VAULT) ROUTES ──
+const fileUploadRoutes = require("./routes/fileUpload");
+app.use(
+  "/services/file-upload",
   protect,
   preventContributorWrites,
-  uploadLimiter,
-  upload.single("file"),
-  async (req, res) => {
-    if (!req.file) {
-      return res.status(400).json({ error: "No file uploaded" });
-    }
-
-    const compressionResult = await compressImage(req.file.path, req.file.mimetype);
-    const finalStats = fs.statSync(req.file.path);
-
-    res.json({
-      filename: req.file.originalname,
-      size: finalStats.size,
-      mimetype: req.file.mimetype,
-      path: req.file.filename,
-      compressed: compressionResult.compressed,
-    });
-
-    // Clean up temporary file to prevent DoS via disk exhaustion
-    try {
-      fs.unlink(req.file.path, (err) => {
-        if (err)
-          console.error(
-            `[upload] Failed to delete temp file ${req.file.path}:`,
-            err,
-          );
-      });
-    } catch (e) {
-      console.error(`[upload] Error deleting temp file:`, e);
-    }
-  },
+  fileUploadRoutes,
 );
 
 // ── SHORT URL REDIRECT ──
@@ -1191,6 +1064,8 @@ app.get(
               $sort: { timestamp: -1 },
               $slice: 1000,
             },
+          },
+        },
         { new: true },
       );
 

--- a/model/vaultFile.js
+++ b/model/vaultFile.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+/**
+ * @schema vaultFileSchema
+ * @description Tracks metadata for files persisted by the Vault (file-upload) service.
+ * The actual file bytes live on disk under the configured Vault storage root;
+ * this collection is the source of truth for ownership, display name, and size.
+ */
+const vaultFileSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    originalName: {
+      type: String,
+      required: true,
+    },
+    storedFilename: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    size: {
+      type: Number,
+      required: true,
+    },
+    mimetype: {
+      type: String,
+      required: true,
+    },
+  },
+  { timestamps: true },
+);
+
+module.exports = mongoose.model("VaultFile", vaultFileSchema);

--- a/routes/fileUpload.js
+++ b/routes/fileUpload.js
@@ -1,0 +1,259 @@
+const express = require("express");
+const path = require("path");
+const fs = require("fs");
+const crypto = require("crypto");
+const multer = require("multer");
+const rateLimit = require("express-rate-limit");
+const sharp = require("sharp");
+const VaultFile = require("../model/vaultFile");
+const asyncHandler = require("../utils/asyncHandler");
+
+const router = express.Router();
+
+// Persistent storage root for Vault uploads. Configurable via env var so
+// deployments can point this at a mounted volume; defaults to a local
+// ./uploads/vault directory (NOT os.tmpdir() — that gets wiped and previously
+// caused uploaded files to vanish immediately after upload, see issue #381).
+const VAULT_ROOT = process.env.VAULT_STORAGE_PATH
+  ? path.resolve(process.env.VAULT_STORAGE_PATH)
+  : path.join(__dirname, "..", "uploads", "vault");
+
+function userVaultDir(userId) {
+  const dir = path.join(VAULT_ROOT, String(userId));
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// Only allow bare filenames we generated ourselves — blocks path traversal
+// via the :filename route param on rename/delete.
+function isSafeFilename(filename) {
+  return (
+    typeof filename === "string" &&
+    filename.length > 0 &&
+    !filename.includes("/") &&
+    !filename.includes("\\") &&
+    filename === path.basename(filename)
+  );
+}
+
+function sanitizeName(name) {
+  return path
+    .basename(name)
+    .replace(/[/\\?%*:|"<>]/g, "-")
+    .replace(/^\.+/, "");
+}
+
+const storage = multer.diskStorage({
+  destination: function (req, file, cb) {
+    try {
+      cb(null, userVaultDir(req.user.id));
+    } catch (err) {
+      cb(err);
+    }
+  },
+  filename: function (req, file, cb) {
+    const sanitizedFilename = sanitizeName(file.originalname);
+    cb(
+      null,
+      Date.now() + "-" + crypto.randomBytes(4).toString("hex") + "-" + sanitizedFilename,
+    );
+  },
+});
+
+const fileFilter = (req, file, cb) => {
+  const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+  const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
+  const fileExtension = path.extname(file.originalname).toLowerCase();
+
+  if (
+    !ALLOWED_MIME_TYPES.includes(file.mimetype) ||
+    !ALLOWED_EXTENSIONS.includes(fileExtension)
+  ) {
+    return cb(
+      new Error("Only image files (JPEG, PNG, WebP, GIF) are allowed."),
+      false,
+    );
+  }
+
+  cb(null, true);
+};
+
+const upload = multer({
+  storage,
+  limits: { fileSize: 50 * 1024 * 1024 },
+  fileFilter,
+});
+
+const uploadLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  message: { error: "Upload limit reached, please try again later." },
+});
+
+async function compressImage(filePath, mimetype) {
+  // GIFs are skipped — sharp's default pipeline doesn't preserve animation
+  if (mimetype === "image/gif") {
+    return { compressed: false };
+  }
+
+  const tempOutputPath = filePath + ".compressed";
+  const originalStats = fs.statSync(filePath);
+
+  try {
+    const pipeline = sharp(filePath).resize({
+      width: 1920,
+      height: 1920,
+      fit: "inside",
+      withoutEnlargement: true,
+    });
+
+    if (mimetype === "image/jpeg") {
+      pipeline.jpeg({ quality: 80 });
+    } else if (mimetype === "image/png") {
+      pipeline.png({ quality: 80, compressionLevel: 8 });
+    } else if (mimetype === "image/webp") {
+      pipeline.webp({ quality: 80 });
+    }
+
+    await pipeline.toFile(tempOutputPath);
+
+    const compressedStats = fs.statSync(tempOutputPath);
+
+    if (compressedStats.size < originalStats.size) {
+      fs.renameSync(tempOutputPath, filePath);
+      return { compressed: true, originalSize: originalStats.size, newSize: compressedStats.size };
+    } else {
+      fs.unlinkSync(tempOutputPath);
+      return { compressed: false, originalSize: originalStats.size, newSize: originalStats.size };
+    }
+  } catch (err) {
+    console.error("[compress] Failed to compress image:", err);
+    if (fs.existsSync(tempOutputPath)) {
+      fs.unlinkSync(tempOutputPath);
+    }
+    return { compressed: false, originalSize: originalStats.size, newSize: originalStats.size };
+  }
+}
+
+// ── UPLOAD ──────────────────────────────────────────────────────────────
+router.post(
+  "/upload",
+  uploadLimiter,
+  upload.single("file"),
+  asyncHandler(async (req, res) => {
+    if (!req.file) {
+      return res.status(400).json({ error: "No file uploaded" });
+    }
+
+    const compressionResult = await compressImage(req.file.path, req.file.mimetype);
+    const finalStats = fs.statSync(req.file.path);
+
+    const vaultFile = await VaultFile.create({
+      userId: req.user.id,
+      originalName: req.file.originalname,
+      storedFilename: req.file.filename,
+      size: finalStats.size,
+      mimetype: req.file.mimetype,
+    });
+
+    // File is persisted on disk and tracked in the Vault collection — no
+    // cleanup/unlink here. This was the root cause of issue #381.
+    return res.json({
+      filename: vaultFile.originalName,
+      size: vaultFile.size,
+      mimetype: vaultFile.mimetype,
+      path: vaultFile.storedFilename,
+      compressed: compressionResult.compressed,
+      originalSize: compressionResult.originalSize,
+    });
+  }),
+);
+
+// ── STORAGE USAGE ──────────────────────────────────────────────────────
+router.get(
+  "/storage-usage",
+  asyncHandler(async (req, res) => {
+    const files = await VaultFile.find({ userId: req.user.id }).select("size").lean();
+    const totalSize = files.reduce((sum, f) => sum + (f.size || 0), 0);
+    return res.json({ success: true, totalSize, fileCount: files.length });
+  }),
+);
+
+// ── RENAME ──────────────────────────────────────────────────────────────
+// Frontend treats the stored filename as the file's identifier and expects
+// it to change after a rename, so we actually rename the file on disk (and
+// its DB record), rather than just relabeling a display name.
+router.patch(
+  "/rename/:filename",
+  asyncHandler(async (req, res) => {
+    const { filename } = req.params;
+    const { newName } = req.body;
+
+    if (!isSafeFilename(filename)) {
+      return res.status(400).json({ success: false, message: "Invalid filename" });
+    }
+    if (!newName || typeof newName !== "string" || !newName.trim()) {
+      return res.status(400).json({ success: false, message: "New name is required" });
+    }
+
+    const vaultFile = await VaultFile.findOne({
+      userId: req.user.id,
+      storedFilename: filename,
+    });
+    if (!vaultFile) {
+      return res.status(404).json({ success: false, message: "File not found" });
+    }
+
+    const sanitizedDisplayName = sanitizeName(newName);
+    if (!sanitizedDisplayName) {
+      return res.status(400).json({ success: false, message: "Invalid new name" });
+    }
+
+    const newStoredFilename =
+      Date.now() + "-" + crypto.randomBytes(4).toString("hex") + "-" + sanitizedDisplayName;
+    const dir = userVaultDir(req.user.id);
+    const oldPath = path.join(dir, vaultFile.storedFilename);
+    const newPath = path.join(dir, newStoredFilename);
+
+    fs.renameSync(oldPath, newPath);
+
+    vaultFile.storedFilename = newStoredFilename;
+    vaultFile.originalName = sanitizedDisplayName;
+    await vaultFile.save();
+
+    return res.json({ success: true, newName: vaultFile.storedFilename });
+  }),
+);
+
+// ── DELETE ──────────────────────────────────────────────────────────────
+router.delete(
+  "/delete/:filename",
+  asyncHandler(async (req, res) => {
+    const { filename } = req.params;
+
+    if (!isSafeFilename(filename)) {
+      return res.status(400).json({ success: false, message: "Invalid filename" });
+    }
+
+    const vaultFile = await VaultFile.findOne({
+      userId: req.user.id,
+      storedFilename: filename,
+    });
+    if (!vaultFile) {
+      return res.status(404).json({ success: false, message: "File not found" });
+    }
+
+    const filePath = path.join(userVaultDir(req.user.id), vaultFile.storedFilename);
+    fs.unlink(filePath, (err) => {
+      if (err && err.code !== "ENOENT") {
+        console.error(`[vault] Failed to delete file ${filePath}:`, err);
+      }
+    });
+
+    await VaultFile.deleteOne({ _id: vaultFile._id });
+
+    return res.json({ success: true });
+  }),
+);
+
+module.exports = router;


### PR DESCRIPTION
## 📝 Description
The Vault file-upload endpoint accepted files via multer but immediately deleted them with `fs.unlink()` right after responding to the client, so every uploaded file was permanently lost. The upload also used `os.tmpdir()` as its only destination, with no persistence layer behind it. Separately, the frontend (`public/js/pages/file-upload.js`) already called `storage-usage`, `rename/:filename`, and `delete/:filename` endpoints that didn't exist anywhere on the server, so those UI actions were silently broken.

This PR moves the Vault upload logic into its own router, adds a `VaultFile` model to track per-user file metadata, persists uploads to a permanent on-disk directory instead of the OS temp dir, and implements the three missing endpoints.

## 🔗 Related Issues
Closes #381

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)

## 🔄 Changes Made
- Moved Vault upload logic out of `index.js` into `routes/fileUpload.js`
- Added `model/vaultFile.js` to track per-user file metadata (owner, original name, stored filename, size, mimetype)
- Files now persist to `uploads/vault/<userId>/` (configurable via `VAULT_STORAGE_PATH` env var) instead of `os.tmpdir()`, and are no longer deleted right after upload
- Implemented `GET /services/file-upload/storage-usage`, `PATCH /services/file-upload/rename/:filename`, and `DELETE /services/file-upload/delete/:filename` — endpoints the frontend already called but which didn't exist server-side
- Rename actually renames the file on disk and its DB record (matching the frontend's expectation that the filename identifier changes after rename), rather than just relabeling a display name
- Added filename validation/sanitization on rename and delete to prevent path traversal via the `:filename` route param
- Added `uploads/` to `.gitignore` so persisted user files are never committed
- **Drive-by fix:** corrected a pre-existing brace mismatch in the `/u/:shortId` route (`Url.findOneAndUpdate` was missing two closing braces), which caused `index.js` to fail to parse at all. This was already broken on `upstream/main` and had to be fixed to load and test the app.

## ✅ Testing
### How to Test
1. Log in and navigate to `/file-upload` (Vault)
2. Upload an image — confirm the success response, then check that the file persists on disk under `uploads/vault/<userId>/` and is **not** deleted
3. Use the Rename button on an uploaded file — confirm the file is renamed on disk and the UI updates to the new identifier
4. Use the Delete button — confirm the file is removed from disk and no longer counted in storage usage
5. Check the storage usage indicator on the page reflects the correct total size/count

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

Not covered by automated tests in this PR — manual testing steps above.

## 🚀 Deployment Notes
- New env var (optional): `VAULT_STORAGE_PATH` — sets the on-disk root for Vault uploads. Defaults to `./uploads/vault` if unset.
- On serverless/ephemeral deployments (e.g. Vercel), local disk storage will not persist across deployments or scale-to-zero — this fix solves the immediate-deletion bug and unblocks local/persistent-disk deployments, but a durable fix for serverless environments would need object storage (e.g. S3), which doesn't currently exist anywhere in this codebase and is out of scope for this PR.

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
The `/u/:shortId` brace-mismatch fix is unrelated to the Vault issue but was blocking `index.js` from parsing at all, so it had to be included to get the app running for testing. Happy to split it into a separate PR if maintainers prefer that instead.