### PR TITLE
feat(dm-automation): match incoming DMs to creator keyword triggers

### DIFF
--- a/controller/instagramWebhookController.js
+++ b/controller/instagramWebhookController.js
@@ -1,7 +1,7 @@
-const dmQueueService = require('../services/dmQueueService');
-const asyncHandler = require('../utils/asyncHandler');
+const dmQueueService = require("../services/dmQueueService");
+const asyncHandler = require("../utils/asyncHandler");
 
-const crypto = require('crypto');
+const crypto = require("crypto");
 
 // Prefer exported dmQueue when present (#981 may add the export separately).
 const dmQueue = dmQueueService && dmQueueService.dmQueue;
@@ -13,173 +13,201 @@ const EVENT_TTL_MS = 5 * 60 * 1000;
 
 // Periodic cleanup of expired event IDs
 const cleanupInterval = setInterval(() => {
-    const now = Date.now();
-    for (const [eventId, timestamp] of processedEvents) {
-        if (now - timestamp > EVENT_TTL_MS) {
-            processedEvents.delete(eventId);
-        }
+  const now = Date.now();
+  for (const [eventId, timestamp] of processedEvents) {
+    if (now - timestamp > EVENT_TTL_MS) {
+      processedEvents.delete(eventId);
     }
+  }
 }, 60 * 1000);
 cleanupInterval.unref();
 
 function hasProcessed(eventId) {
-    if (!eventId) return false;
-    return processedEvents.has(eventId);
+  if (!eventId) return false;
+  return processedEvents.has(eventId);
 }
 
 function markProcessed(eventId) {
-    if (!eventId) return;
-    processedEvents.set(eventId, Date.now());
+  if (!eventId) return;
+  processedEvents.set(eventId, Date.now());
 }
 
 function clearProcessedEvents() {
-    processedEvents.clear();
+  processedEvents.clear();
 }
 
 // Verify the webhook from Meta
 const verifyWebhook = (req, res) => {
-    const VERIFY_TOKEN = process.env.INSTAGRAM_WEBHOOK_VERIFY_TOKEN;
+  const VERIFY_TOKEN = process.env.INSTAGRAM_WEBHOOK_VERIFY_TOKEN;
 
-    if (!VERIFY_TOKEN) {
-        console.error('[Webhook] INSTAGRAM_WEBHOOK_VERIFY_TOKEN is not configured');
-        return res.sendStatus(500);
+  if (!VERIFY_TOKEN) {
+    console.error("[Webhook] INSTAGRAM_WEBHOOK_VERIFY_TOKEN is not configured");
+    return res.sendStatus(500);
+  }
+
+  const mode = req.query["hub.mode"];
+  const token = req.query["hub.verify_token"];
+  const challenge = req.query["hub.challenge"];
+
+  if (mode && token) {
+    if (mode === "subscribe" && token === VERIFY_TOKEN) {
+      console.log("WEBHOOK_VERIFIED");
+      return res.status(200).send(challenge);
+    } else {
+      return res.sendStatus(403);
     }
+  }
 
-    const mode = req.query['hub.mode'];
-    const token = req.query['hub.verify_token'];
-    const challenge = req.query['hub.challenge'];
-
-    if (mode && token) {
-        if (mode === 'subscribe' && token === VERIFY_TOKEN) {
-            console.log('WEBHOOK_VERIFIED');
-            return res.status(200).send(challenge);
-        } else {
-            return res.sendStatus(403);
-        }
-    }
-    
-    return res.status(400).send('Missing hub variables');
+  return res.status(400).send("Missing hub variables");
 };
 
 const verifyWebhookSignature = (req, res, next) => {
-    const signature = req.headers['x-hub-signature-256'];
-    
-    if (!signature) {
-        console.warn('[Webhook] Missing X-Hub-Signature-256 header');
-        return res.sendStatus(403);
-    }
-    
-    const APP_SECRET = process.env.INSTAGRAM_APP_SECRET;
-    
-    if (!APP_SECRET) {
-        console.error('[Webhook] INSTAGRAM_APP_SECRET is not configured');
-        return res.sendStatus(500);
-    }
-    
-    const payload = req.rawBody;
-    
-    if (!payload) {
-        console.error('[Webhook] Raw body is missing. Ensure express.json({verify: ...}) is configured.');
-        return res.sendStatus(500);
-    }
+  const signature = req.headers["x-hub-signature-256"];
 
-    const expectedSignature = 'sha256=' + crypto.createHmac('sha256', APP_SECRET).update(payload).digest('hex');
-
-    try {
-        if (crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
-            return next();
-        }
-    } catch (e) {
-        // catch error if buffer lengths don't match
-    }
-
-    console.warn('[Webhook] Invalid signature');
+  if (!signature) {
+    console.warn("[Webhook] Missing X-Hub-Signature-256 header");
     return res.sendStatus(403);
+  }
+
+  const APP_SECRET = process.env.INSTAGRAM_APP_SECRET;
+
+  if (!APP_SECRET) {
+    console.error("[Webhook] INSTAGRAM_APP_SECRET is not configured");
+    return res.sendStatus(500);
+  }
+
+  const payload = req.rawBody;
+
+  if (!payload) {
+    console.error(
+      "[Webhook] Raw body is missing. Ensure express.json({verify: ...}) is configured.",
+    );
+    return res.sendStatus(500);
+  }
+
+  const expectedSignature =
+    "sha256=" +
+    crypto.createHmac("sha256", APP_SECRET).update(payload).digest("hex");
+
+  try {
+    if (
+      crypto.timingSafeEqual(
+        Buffer.from(signature),
+        Buffer.from(expectedSignature),
+      )
+    ) {
+      return next();
+    }
+  } catch (e) {
+    // catch error if buffer lengths don't match
+  }
+
+  console.warn("[Webhook] Invalid signature");
+  return res.sendStatus(403);
 };
 
-async function enqueueDmEvent(eventId, senderId, messageText) {
-    if (!dmQueue || typeof dmQueue.add !== 'function') {
-        throw new Error('DM queue unavailable');
-    }
+async function enqueueDmEvent(eventId, senderId, messageText, recipientId) {
+  if (!dmQueue || typeof dmQueue.add !== "function") {
+    throw new Error("DM queue unavailable");
+  }
 
-    await dmQueue.add('process-dm', {
-        senderId: senderId,
-        message: messageText,
-        triggerKeyword: messageText.toLowerCase(),
-        eventId: eventId,
-    }, {
-        attempts: 5,
-        backoff: {
-            type: 'exponential',
-            delay: 2000
-        },
-        jobId: eventId,
-    });
+  await dmQueue.add(
+    "process-dm",
+    {
+      senderId: senderId,
+      recipientId: recipientId,
+      message: messageText,
+      triggerKeyword: messageText.toLowerCase(),
+      eventId: eventId,
+    },
+    {
+      attempts: 5,
+      backoff: {
+        type: "exponential",
+        delay: 2000,
+      },
+      jobId: eventId,
+    },
+  );
 }
 
 // Handle incoming webhook events
 const handleWebhook = asyncHandler(async (req, res, next) => {
-    const body = req.body || {};
+  const body = req.body || {};
 
-    // Check for duplicate event using X-Event-ID header or payload-level deduplication
-    const headerEventId = req.headers['x-event-id'];
-    let enqueueFailed = false;
-    
-    // Check if it's a page or instagram event
-    if (body.object === 'instagram') {
-        if (body.entry && body.entry.length > 0) {
-            for (const entry of body.entry) {
-                if (entry.messaging && entry.messaging.length > 0) {
-                    for (const webhookEvent of entry.messaging) {
-                        const senderId = webhookEvent?.sender?.id;
-                        const message = webhookEvent?.message;
-                        const timestamp = webhookEvent?.timestamp;
+  // Check for duplicate event using X-Event-ID header or payload-level deduplication
+  const headerEventId = req.headers["x-event-id"];
+  let enqueueFailed = false;
 
-                        if (senderId && message && message.text) {
-                            // Build a unique event ID from sender + message + timestamp for deduplication
-                            const eventId = headerEventId || crypto
-                                .createHash('sha256')
-                                .update(`${senderId}:${message.mid || message.text}:${timestamp || Date.now()}`)
-                                .digest('hex');
+  // Check if it's a page or instagram event
+  if (body.object === "instagram") {
+    if (body.entry && body.entry.length > 0) {
+      for (const entry of body.entry) {
+        const recipientId = entry.id;
+        if (entry.messaging && entry.messaging.length > 0) {
+          for (const webhookEvent of entry.messaging) {
+            const senderId = webhookEvent?.sender?.id;
+            const message = webhookEvent?.message;
+            const timestamp = webhookEvent?.timestamp;
 
-                            if (hasProcessed(eventId)) {
-                                console.log(`[Webhook] Duplicate event ${eventId}, skipping`);
-                                continue;
-                            }
+            if (senderId && message && message.text) {
+              // Build a unique event ID from sender + message + timestamp for deduplication
+              const eventId =
+                headerEventId ||
+                crypto
+                  .createHash("sha256")
+                  .update(
+                    `${senderId}:${message.mid || message.text}:${timestamp || Date.now()}`,
+                  )
+                  .digest("hex");
 
-                            console.log(`[Webhook] Received message from ${senderId}: ${message.text}`);
-                            
-                            // Enqueue first; only mark processed after a successful add so Meta can retry on failure.
-                            try {
-                                await enqueueDmEvent(eventId, senderId, message.text);
-                                markProcessed(eventId);
-                            } catch (error) {
-                                enqueueFailed = true;
-                                console.warn(`[Webhook] DM queue enqueue failed: ${error.message}`);
-                            }
-                        }
-                    }
-                }
+              if (hasProcessed(eventId)) {
+                console.log(`[Webhook] Duplicate event ${eventId}, skipping`);
+                continue;
+              }
+
+              console.log(
+                `[Webhook] Received message from ${senderId}: ${message.text}`,
+              );
+
+              // Enqueue first; only mark processed after a successful add so Meta can retry on failure.
+              try {
+                await enqueueDmEvent(
+                  eventId,
+                  senderId,
+                  message.text,
+                  recipientId,
+                );
+                markProcessed(eventId);
+              } catch (error) {
+                enqueueFailed = true;
+                console.warn(
+                  `[Webhook] DM queue enqueue failed: ${error.message}`,
+                );
+              }
             }
+          }
         }
-
-        if (enqueueFailed) {
-            // Ask Meta to retry; successfully enqueued events stay marked and will be skipped.
-            return res.status(503).send('SERVICE_UNAVAILABLE');
-        }
-        
-        return res.status(200).send('EVENT_RECEIVED');
-    } else {
-        // Return a '404 Not Found' if event is not from a supported object
-        return res.sendStatus(404);
+      }
     }
+
+    if (enqueueFailed) {
+      // Ask Meta to retry; successfully enqueued events stay marked and will be skipped.
+      return res.status(503).send("SERVICE_UNAVAILABLE");
+    }
+
+    return res.status(200).send("EVENT_RECEIVED");
+  } else {
+    // Return a '404 Not Found' if event is not from a supported object
+    return res.sendStatus(404);
+  }
 });
 
 module.exports = {
-    verifyWebhook,
-    verifyWebhookSignature,
-    handleWebhook,
-    hasProcessed,
-    markProcessed,
-    clearProcessedEvents,
+  verifyWebhook,
+  verifyWebhookSignature,
+  handleWebhook,
+  hasProcessed,
+  markProcessed,
+  clearProcessedEvents,
 };

--- a/services/dmQueueService.js
+++ b/services/dmQueueService.js
@@ -1,5 +1,7 @@
-const { Queue, Worker } = require('bullmq');
-const IORedis = require('ioredis');
+const { Queue, Worker } = require("bullmq");
+const IORedis = require("ioredis");
+const Creator = require("../model/creator");
+const DmTrigger = require("../model/dmTrigger");
 
 // BullMQ requires a standard Redis connection string (socket protocol).
 const REDIS_URI = process.env.REDIS_URI || process.env.REDIS_URL;
@@ -8,18 +10,18 @@ const REDIS_URI = process.env.REDIS_URI || process.env.REDIS_URL;
 const { UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN } = process.env;
 
 function createFallbackQueue() {
-    return {
-        async add(jobName, jobData) {
-            console.warn(
-                `[DM Queue] Redis is not configured, skipping job "${jobName}" for sender ${jobData?.senderId || 'unknown'}.`
-            );
-            return {
-                id: null,
-                name: jobName,
-                data: jobData,
-            };
-        },
-    };
+  return {
+    async add(jobName, jobData) {
+      console.warn(
+        `[DM Queue] Redis is not configured, skipping job "${jobName}" for sender ${jobData?.senderId || "unknown"}.`,
+      );
+      return {
+        id: null,
+        name: jobName,
+        data: jobData,
+      };
+    },
+  };
 }
 
 let dmQueue = createFallbackQueue();
@@ -27,127 +29,187 @@ let dmWorker = null;
 
 // Send Instagram DM via Instagram Graph API
 async function sendInstagramDM(recipientId, text, options = {}) {
-    const accessToken = options.accessToken || process.env.INSTAGRAM_PAGE_ACCESS_TOKEN || process.env.INSTAGRAM_ACCESS_TOKEN;
+  const accessToken =
+    options.accessToken ||
+    process.env.INSTAGRAM_PAGE_ACCESS_TOKEN ||
+    process.env.INSTAGRAM_ACCESS_TOKEN;
 
-    if (!accessToken) {
-        throw new Error('Instagram Page Access Token is not configured (INSTAGRAM_PAGE_ACCESS_TOKEN / INSTAGRAM_ACCESS_TOKEN). Outbound DM delivery failed.');
+  if (!accessToken) {
+    throw new Error(
+      "Instagram Page Access Token is not configured (INSTAGRAM_PAGE_ACCESS_TOKEN / INSTAGRAM_ACCESS_TOKEN). Outbound DM delivery failed.",
+    );
+  }
+
+  if (!recipientId || !text) {
+    throw new Error(
+      "Recipient ID and message text are required for Instagram DM delivery.",
+    );
+  }
+
+  const url = `https://graph.instagram.com/v19.0/me/messages?access_token=${accessToken}`;
+  const payload = {
+    recipient: { id: recipientId },
+    message: { text },
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    let errorData;
+    try {
+      errorData = JSON.parse(errorText);
+    } catch (_) {
+      errorData = {};
     }
 
-    if (!recipientId || !text) {
-        throw new Error('Recipient ID and message text are required for Instagram DM delivery.');
-    }
+    const statusCode = response.status;
+    const message =
+      errorData.error?.message ||
+      errorText ||
+      `Instagram API HTTP ${statusCode}`;
+    const error = new Error(
+      `Instagram DM Delivery Error (${statusCode}): ${message}`,
+    );
+    error.code = statusCode;
+    error.apiError = errorData.error;
+    throw error;
+  }
 
-    const url = `https://graph.instagram.com/v19.0/me/messages?access_token=${accessToken}`;
-    const payload = {
-        recipient: { id: recipientId },
-        message: { text }
-    };
-
-    const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-    });
-
-    if (!response.ok) {
-        const errorText = await response.text().catch(() => '');
-        let errorData;
-        try {
-            errorData = JSON.parse(errorText);
-        } catch (_) {
-            errorData = {};
-        }
-
-        const statusCode = response.status;
-        const message = errorData.error?.message || errorText || `Instagram API HTTP ${statusCode}`;
-        const error = new Error(`Instagram DM Delivery Error (${statusCode}): ${message}`);
-        error.code = statusCode;
-        error.apiError = errorData.error;
-        throw error;
-    }
-
-    return await response.json().catch(() => ({ success: true }));
+  return await response.json().catch(() => ({ success: true }));
 }
 
 function createRedisConnection(label) {
-    const connection = new IORedis(REDIS_URI, {
-        maxRetriesPerRequest: null,
-        connectTimeout: 5000,
-        lazyConnect: true,
-    });
+  const connection = new IORedis(REDIS_URI, {
+    maxRetriesPerRequest: null,
+    connectTimeout: 5000,
+    lazyConnect: true,
+  });
 
-    // Add listeners for Redis connection events to improve observability.
-    connection.on('error', (err) => {
-        console.error(`❌ Redis Connection Error (${label}):`, err.message);
-    });
+  // Add listeners for Redis connection events to improve observability.
+  connection.on("error", (err) => {
+    console.error(`❌ Redis Connection Error (${label}):`, err.message);
+  });
 
-    return connection;
+  return connection;
 }
 
 // Initialize BullMQ worker and queue if a standard Redis URI is provided.
 // Queue and Worker must use separate sockets: workers issue blocking commands
 // (BRPOP/BLPOP) that starve shared connections used for queue.add().
 if (REDIS_URI) {
-    const queueConnection = createRedisConnection('dm-queue');
+  const queueConnection = createRedisConnection("dm-queue");
 
-    // Create the Queue only when Redis is explicitly configured.
-    dmQueue = new Queue('dm-automation-queue', { connection: queueConnection });
+  // Create the Queue only when Redis is explicitly configured.
+  dmQueue = new Queue("dm-automation-queue", { connection: queueConnection });
 
-    // Create the Worker only when Redis is available and not on Vercel.
-    if (process.env.VERCEL === '1') {
-        console.warn("📦 DM Worker disabled on Vercel to prevent hanging Redis connections. Use Vercel Cron/Webhooks instead.");
-    } else {
-        const workerConnection = createRedisConnection('dm-worker');
+  // Create the Worker only when Redis is available and not on Vercel.
+  if (process.env.VERCEL === "1") {
+    console.warn(
+      "📦 DM Worker disabled on Vercel to prevent hanging Redis connections. Use Vercel Cron/Webhooks instead.",
+    );
+  } else {
+    const workerConnection = createRedisConnection("dm-worker");
 
-        dmWorker = new Worker('dm-automation-queue', async (job) => {
-            const { senderId, message, triggerKeyword, accessToken, responseText: customResponseText } = job.data;
-            
-            console.log(`[Worker] Processing job ${job.id} for sender ${senderId}`);
+    dmWorker = new Worker(
+      "dm-automation-queue",
+      async (job) => {
+        const { senderId, recipientId, message } = job.data;
 
-            try {
-                // Send the DM via Instagram Graph API
-                const responseText = customResponseText || `Hi! You triggered this via "${triggerKeyword}". Here is your resource!`;
-                const result = await sendInstagramDM(senderId, responseText, { accessToken });
-                
-                console.log(`[Worker] Successfully processed job ${job.id}`);
-                return result;
-            } catch (error) {
-                if (error.code === 429 || error.code === 503) {
-                    console.warn(`[Worker] Rate limited/temporary failure (${error.code}) on job ${job.id}. Will retry...`);
-                }
-                throw error;
-            }
-        }, {
-            connection: workerConnection,
-            // Add rate limit pacing (e.g., max 50 jobs per 10 seconds)
-            limiter: {
-                max: 50,
-                duration: 10000,
-            }
-        });
+        console.log(`[Worker] Processing job ${job.id} for sender ${senderId}`);
 
-        // Event Listeners for logging
-        dmWorker.on('completed', (job) => {
-            console.log(`[Worker] Job ${job.id} for sender ${job.data.senderId} completed.`);
-        });
+        try {
+          // Resolve which creator owns this Instagram account
+          const creator = await Creator.findOne({
+            platform: "instagram",
+            platformId: recipientId,
+          });
+          if (!creator) {
+            console.warn(
+              `[Worker] No creator found for recipientId ${recipientId}, skipping job ${job.id}`,
+            );
+            return { skipped: true, reason: "unknown_creator" };
+          }
 
-        dmWorker.on('failed', (job, err) => {
-            const jobId = job?.id || 'unknown';
-            const errorMsg = err?.message || 'unknown error';
-            console.error(`❌ Job with id ${jobId} has failed with ${errorMsg}`);
-            if (job?.attemptsMade && job?.opts?.attempts && job.attemptsMade >= job.opts.attempts) {
-                console.error(`🚨 ALARM: Job ${jobId} completely failed after ${job.attemptsMade} attempts.`);
-            }
-        });
-    }
+          // Find an active trigger whose keyword appears in the message
+          const triggers = await DmTrigger.find({
+            creatorId: creator.userId,
+            isActive: true,
+          });
+          const normalizedMessage = (message || "").toLowerCase();
+          const matchedTrigger = triggers.find((t) =>
+            normalizedMessage.includes(t.keyword),
+          );
 
-    console.log('📦 DM Automation Queue initialized');
+          if (!matchedTrigger) {
+            console.log(
+              `[Worker] No matching trigger for job ${job.id}, skipping reply`,
+            );
+            return { skipped: true, reason: "no_matching_trigger" };
+          }
+
+          const responseText = matchedTrigger.responseUrl;
+          const result = await sendInstagramDM(senderId, responseText, {
+            accessToken: creator.accessToken,
+          });
+
+          console.log(`[Worker] Successfully processed job ${job.id}`);
+          return result;
+        } catch (error) {
+          if (error.code === 429 || error.code === 503) {
+            console.warn(
+              `[Worker] Rate limited/temporary failure (${error.code}) on job ${job.id}. Will retry...`,
+            );
+          }
+          throw error;
+        }
+      },
+      {
+        connection: workerConnection,
+        // Add rate limit pacing (e.g., max 50 jobs per 10 seconds)
+        limiter: {
+          max: 50,
+          duration: 10000,
+        },
+      },
+    );
+
+    // Event Listeners for logging
+    dmWorker.on("completed", (job) => {
+      console.log(
+        `[Worker] Job ${job.id} for sender ${job.data.senderId} completed.`,
+      );
+    });
+
+    dmWorker.on("failed", (job, err) => {
+      const jobId = job?.id || "unknown";
+      const errorMsg = err?.message || "unknown error";
+      console.error(`❌ Job with id ${jobId} has failed with ${errorMsg}`);
+      if (
+        job?.attemptsMade &&
+        job?.opts?.attempts &&
+        job.attemptsMade >= job.opts.attempts
+      ) {
+        console.error(
+          `🚨 ALARM: Job ${jobId} completely failed after ${job.attemptsMade} attempts.`,
+        );
+      }
+    });
+  }
+
+  console.log("📦 DM Automation Queue initialized");
 } else {
-    console.warn('📦 BullMQ DM Automation Queue disabled: REDIS_URI/REDIS_URL is not set.');
+  console.warn(
+    "📦 BullMQ DM Automation Queue disabled: REDIS_URI/REDIS_URL is not set.",
+  );
 }
 
 if (UPSTASH_REDIS_REST_URL && UPSTASH_REDIS_REST_TOKEN) {
-    console.log('📦 Upstash Redis REST client configured.');
+  console.log("📦 Upstash Redis REST client configured.");
 }
 
 module.exports = { dmQueue, dmWorker, sendInstagramDM };


### PR DESCRIPTION
## 📝 Description
Wires keyword-based DM automation end-to-end: incoming Instagram DMs are now matched against a creator's configured `DmTrigger` keywords, and the correct `responseUrl` is sent back — instead of the previous hardcoded generic reply. This is the first working slice of the Keyword Automation / Auto Replies features from #964.

## 🔗 Related Issues
closes #964

## 📋 Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## 🔄 Changes Made
- Capture recipient/page id (`entry.id`) from each incoming webhook entry and pass it through the BullMQ job payload
- Worker resolves the owning `Creator` via `Creator.platformId` to scope the trigger lookup to the correct account
- Match message text against that creator's active `DmTrigger` keywords (substring match)
- Send the trigger's configured `responseUrl` via the creator's own `accessToken`, instead of the old generic canned reply
- Jobs with no matching creator or no matching trigger are skipped and logged, rather than sending a fallback message

## ✅ Testing
### How to Test
1. Seed a `Creator` doc with `platform: "instagram"`, a `platformId`, and an `accessToken`
2. Seed a `DmTrigger` for that creator's `userId` with a `keyword` and `responseUrl`, `isActive: true`
3. POST a mock webhook payload to `/webhook` with `entry.id` matching the creator's `platformId` and a message containing the keyword — confirm the worker sends `responseUrl` and not the old generic text; test a non-matching keyword and confirm it's skipped

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 🚀 Deployment Notes
No env/config changes required — reuses existing `Creator` and `DmTrigger` models and the existing `INSTAGRAM_WEBHOOK_VERIFY_TOKEN` / Redis setup.

## ⚠️ Breaking Changes
- None. Prior behavior (generic canned reply for every DM) is replaced with trigger-based matching; DMs with no configured trigger now go unanswered instead of getting a placeholder reply, which is the intended production behavior.

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Test coverage is still open — happy to add a unit test for the worker's trigger-matching logic (mocking `Creator`/`DmTrigger`) if maintainers want it before merge. Matching is currently substring-based (`message.includes(keyword)`); exact-phrase or multi-keyword logic could be a fast follow-up.