### PR TITLE
Feature/hf file storage 962 

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,8 +155,6 @@ app.set("view engine", "ejs");
 app.set("views", path.join(__dirname, "view"));
 app.locals.BRAND = BRAND;
 
-
-
 const urlShortenerLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 30,
@@ -171,7 +169,6 @@ const {
   redirectIfAuthenticated,
 } = require("./middleware/auth");
 
-const fs = require("fs");
 app.use(express.static(path.join(__dirname, "public")));
 const shortid = require("shortid");
 const services = require("./services.config");
@@ -180,6 +177,7 @@ const Creator = require("./model/creator");
 const Invite = require("./model/invite");
 const BioProfile = require("./model/bioProfile");
 const Url = require("./model/url");
+const UploadFile = require("./model/upload");
 const port = process.env.PORT || 3000;
 const asyncHandler = require("./utils/asyncHandler");
 
@@ -228,8 +226,6 @@ app.use(
       "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.0.0/swagger-ui.min.css",
   }),
 );
-
-
 
 // ── HELPERS ──────────────────────────────────────────────────────────────────
 
@@ -369,46 +365,60 @@ async function buildAnalyticsViewModel(userId, shortLinkId = null) {
   });
 
   const breakdown = { device: {}, browser: {}, referrer: {}, country: {} };
-  userUrls.forEach(url => {
-      (url.visitHistory || []).forEach(v => {
-          if (v.device) breakdown.device[v.device] = (breakdown.device[v.device] || 0) + 1;
-          if (v.browser) breakdown.browser[v.browser] = (breakdown.browser[v.browser] || 0) + 1;
-          if (v.referrer) breakdown.referrer[v.referrer] = (breakdown.referrer[v.referrer] || 0) + 1;
-          if (v.country) breakdown.country[v.country] = (breakdown.country[v.country] || 0) + 1;
-      });
+  userUrls.forEach((url) => {
+    (url.visitHistory || []).forEach((v) => {
+      if (v.device)
+        breakdown.device[v.device] = (breakdown.device[v.device] || 0) + 1;
+      if (v.browser)
+        breakdown.browser[v.browser] = (breakdown.browser[v.browser] || 0) + 1;
+      if (v.referrer)
+        breakdown.referrer[v.referrer] =
+          (breakdown.referrer[v.referrer] || 0) + 1;
+      if (v.country)
+        breakdown.country[v.country] = (breakdown.country[v.country] || 0) + 1;
+    });
   });
 
-  const linkPosts = (userUrls || []).map((u) => ({
-      title: u.title || u.redirectUrl?.slice(0, 50) || 'Shortlink',
-      type: u.tag ? u.tag.toUpperCase() : 'LINK',
-      likes: '—',
-      comments: '—',
+  const linkPosts = (userUrls || [])
+    .map((u) => ({
+      title: u.title || u.redirectUrl?.slice(0, 50) || "Shortlink",
+      type: u.tag ? u.tag.toUpperCase() : "LINK",
+      likes: "—",
+      comments: "—",
       views: u.totalClicks || 0,
       engagement: `${u.totalClicks || 0} clicks`,
       date: u.createdAt
-          ? new Date(u.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-          : 'Today',
-  })).sort((a, b) => (b.views || 0) - (a.views || 0)).slice(0, 10);
+        ? new Date(u.createdAt).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+          })
+        : "Today",
+    }))
+    .sort((a, b) => (b.views || 0) - (a.views || 0))
+    .slice(0, 10);
 
   return {
-      isLoading: false,
-      isEmpty: userUrls.length === 0,
-      selectedRange: 'Last 30 days',
-      lastUpdated: new Date().toLocaleString('en-US', {
-          day: '2-digit', month: 'short', year: 'numeric',
-          hour: 'numeric', minute: '2-digit',
-      }),
-      metrics: [],
-      charts: {
-          labels,
-          followers,
-          engagement,
-          posts: linkPosts.map((p) => p.title),
-          postPerformance: linkPosts.map((p) => p.views),
-      },
-      topPosts: linkPosts,
-      breakdown,
-      totalClicks: userUrls.reduce((sum, u) => sum + (u.totalClicks || 0), 0),
+    isLoading: false,
+    isEmpty: userUrls.length === 0,
+    selectedRange: "Last 30 days",
+    lastUpdated: new Date().toLocaleString("en-US", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }),
+    metrics: [],
+    charts: {
+      labels,
+      followers,
+      engagement,
+      posts: linkPosts.map((p) => p.title),
+      postPerformance: linkPosts.map((p) => p.views),
+    },
+    topPosts: linkPosts,
+    breakdown,
+    totalClicks: userUrls.reduce((sum, u) => sum + (u.totalClicks || 0), 0),
   };
 }
 
@@ -829,24 +839,6 @@ const clickCooldownsSweepInterval = setInterval(() => {
 }, CLEANUP_INTERVAL_MS);
 clickCooldownsSweepInterval.unref();
 
-// Periodic cleanup every 5 minutes to prevent unbounded memory growth
-setInterval(
-  () => {
-    const now = Date.now();
-    for (const [linkId, linkCooldowns] of clickCooldowns) {
-      for (const [ip, timestamp] of linkCooldowns) {
-        if (now - timestamp > CLICK_COOLDOWN_MS) {
-          linkCooldowns.delete(ip);
-        }
-      }
-      if (linkCooldowns.size === 0) {
-        clickCooldowns.delete(linkId);
-      }
-    }
-  },
-  5 * 60 * 1000,
-);
-
 app.post(
   "/bio/track/:linkId",
   clickTrackerLimiter,
@@ -1028,13 +1020,19 @@ app.get(
 
 // ── URL SHORTENER POST ──
 
-const { isValidUrl } = require('./utils/validators');
-const { parseVisitCoordinates } = require('./utils/visitTelemetry');
-const { parseVisitMeta } = require('./utils/deviceParser');
+const { isValidUrl } = require("./utils/validators");
+const { parseVisitCoordinates } = require("./utils/visitTelemetry");
+const { parseVisitMeta } = require("./utils/deviceParser");
 
-const { handleGenerateShortUrlRender } = require('./controller/url');
-const { handleQrRedirect } = require('./controller/qrCodeController');
-app.post('/services/url-shortener/shorten', protect, preventContributorWrites, urlShortenerLimiter, handleGenerateShortUrlRender);
+const { handleGenerateShortUrlRender } = require("./controller/url");
+const { handleQrRedirect } = require("./controller/qrCodeController");
+app.post(
+  "/services/url-shortener/shorten",
+  protect,
+  preventContributorWrites,
+  urlShortenerLimiter,
+  handleGenerateShortUrlRender,
+);
 
 // ── FILE UPLOAD (VAULT) ROUTES ──
 const fileUploadRoutes = require("./routes/fileUpload");
@@ -1095,23 +1093,6 @@ app.get(
       if (entry.password) {
         return res.render("link-password", { shortId, error: null });
       }
-      Object.assign(visitData, parseVisitMeta(req));
-
-      const entry = await Url.findOneAndUpdate(
-        { shortId },
-        {
-          $inc: { totalClicks: 1 },
-          $push: {
-            visitHistory: {
-              $each: [visitData],
-              $sort: { timestamp: -1 },
-              $slice: 1000,
-            },
-          },
-        },
-        { new: true },
-      );
-
       return await recordClickAndRedirect(req, res, entry);
     } catch (err) {
       console.error("[redirect]", err);

--- a/model/upload.js
+++ b/model/upload.js
@@ -1,0 +1,23 @@
+const mongoose = require("mongoose");
+
+const uploadSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    filename: { type: String, required: true },
+    hfPath: { type: String, required: true },
+    url: { type: String, required: true },
+    mimetype: { type: String, required: true },
+    size: { type: Number, required: true },
+    folder: { type: String, default: "" },
+  },
+  { timestamps: true },
+);
+
+uploadSchema.index({ filename: "text" });
+
+module.exports = mongoose.model("Upload", uploadSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@huggingface/hub": "^2.15.0",
         "archiver": "^8.0.0",
         "bcryptjs": "^3.0.3",
         "brace-expansion": "^2.1.2",
@@ -553,6 +554,47 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@huggingface/blake3-jit": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@huggingface/blake3-jit/-/blake3-jit-0.0.2.tgz",
+      "integrity": "sha512-Bq7B5qabyjrJfhBsl85Jd2QBtf+HzRD7h7A9GfN2lzrrsABhOa5evVPgzoCTxR7Ub0QFj7YDK1YkYRWBU25+2w==",
+      "license": "MIT"
+    },
+    "node_modules/@huggingface/hub": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/hub/-/hub-2.15.0.tgz",
+      "integrity": "sha512-+sHWNz0YpqTvwuIYDxpyrhyk1o2j9lIJuPzbhUT0kxU8IHP9ZOzeajk/O6RRbZyvAM9h6m219FghDLi0Ayblww==",
+      "license": "MIT",
+      "dependencies": {
+        "@huggingface/tasks": "^0.21.33",
+        "@huggingface/xetchunk-wasm": "^0.1.0"
+      },
+      "bin": {
+        "hfjs": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "cli-progress": "^3.12.0"
+      }
+    },
+    "node_modules/@huggingface/tasks": {
+      "version": "0.21.33",
+      "resolved": "https://registry.npmjs.org/@huggingface/tasks/-/tasks-0.21.33.tgz",
+      "integrity": "sha512-efQa8g+WjPwzlwk7Wl4eDgbM1Jq+WooUw/b1+eKl2LVUdPMhnbwsFNMJJxhEywaLJvJBy93+jjna6855U9GePw==",
+      "license": "MIT"
+    },
+    "node_modules/@huggingface/xetchunk-wasm": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/xetchunk-wasm/-/xetchunk-wasm-0.1.0.tgz",
+      "integrity": "sha512-wWpp2qwPgf9kv1KLJjcDUk/OrpDOsFoQ3Qpz0U5LGn20csoymBf8eneOv6wm/GzPBzlWac1OYiR0aa1vT6aM2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@huggingface/blake3-jit": "0.0.2",
+        "gearhash-jit": "1.0.2"
       }
     },
     "node_modules/@img/colour": {
@@ -3780,6 +3822,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "dev": true,
@@ -4910,6 +4965,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/gearhash-jit": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gearhash-jit/-/gearhash-jit-1.0.2.tgz",
+      "integrity": "sha512-UhzJL4KXSdqAKepy/tZwmi2Rcy0YMmtiC4DQS4SURCuIWdh8ECZtnXK2ePRMLigfB61hRKdLK/Vgg2bSw73izQ==",
+      "license": "MIT"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -544,6 +543,28 @@
       "version": "0.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
@@ -2959,7 +2980,6 @@
     "node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3240,7 +3260,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -3537,7 +3556,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -4542,7 +4560,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9585,7 +9602,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@huggingface/hub": "^2.15.0",
     "archiver": "^8.0.0",
     "bcryptjs": "^3.0.3",
     "brace-expansion": "^2.1.2",

--- a/routes/fileUpload.js
+++ b/routes/fileUpload.js
@@ -1,27 +1,34 @@
 const express = require("express");
 const path = require("path");
-const fs = require("fs");
 const crypto = require("crypto");
 const multer = require("multer");
 const rateLimit = require("express-rate-limit");
 const sharp = require("sharp");
-const VaultFile = require("../model/vaultFile");
+const {
+  uploadFile: hfUploadFile,
+  deleteFiles: hfDeleteFiles,
+} = require("@huggingface/hub");
+const Upload = require("../model/upload");
 const asyncHandler = require("../utils/asyncHandler");
 
 const router = express.Router();
 
-// Persistent storage root for Vault uploads. Configurable via env var so
-// deployments can point this at a mounted volume; defaults to a local
-// ./uploads/vault directory (NOT os.tmpdir() — that gets wiped and previously
-// caused uploaded files to vanish immediately after upload, see issue #381).
-const VAULT_ROOT = process.env.VAULT_STORAGE_PATH
-  ? path.resolve(process.env.VAULT_STORAGE_PATH)
-  : path.join(__dirname, "..", "uploads", "vault");
+const HF_TOKEN = process.env.HF_TOKEN;
+const HF_REPO = process.env.HF_DATASET_REPO;
+const HF_REPO_DESIGNATION = { type: "dataset", name: HF_REPO };
 
-function userVaultDir(userId) {
-  const dir = path.join(VAULT_ROOT, String(userId));
-  fs.mkdirSync(dir, { recursive: true });
-  return dir;
+function assertHfConfigured() {
+  if (!HF_TOKEN || !HF_REPO) {
+    const err = new Error(
+      "Hugging Face storage is not configured (HF_TOKEN / HF_DATASET_REPO missing).",
+    );
+    err.status = 500;
+    throw err;
+  }
+}
+
+function hfPublicUrl(hfPath) {
+  return `https://huggingface.co/datasets/${HF_REPO}/resolve/main/${hfPath}`;
 }
 
 // Only allow bare filenames we generated ourselves — blocks path traversal
@@ -43,45 +50,32 @@ function sanitizeName(name) {
     .replace(/^\.+/, "");
 }
 
-const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
-    try {
-      cb(null, userVaultDir(req.user.id));
-    } catch (err) {
-      cb(err);
-    }
-  },
-  filename: function (req, file, cb) {
-    const sanitizedFilename = sanitizeName(file.originalname);
-    cb(
-      null,
-      Date.now() + "-" + crypto.randomBytes(4).toString("hex") + "-" + sanitizedFilename,
-    );
-  },
-});
-
-const fileFilter = (req, file, cb) => {
-  const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
-  const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
-  const fileExtension = path.extname(file.originalname).toLowerCase();
-
-  if (
-    !ALLOWED_MIME_TYPES.includes(file.mimetype) ||
-    !ALLOWED_EXTENSIONS.includes(fileExtension)
-  ) {
-    return cb(
-      new Error("Only image files (JPEG, PNG, WebP, GIF) are allowed."),
-      false,
-    );
-  }
-
-  cb(null, true);
-};
-
+// Buffer in memory — we upload straight to Hugging Face, never touch local disk.
 const upload = multer({
-  storage,
+  storage: multer.memoryStorage(),
   limits: { fileSize: 50 * 1024 * 1024 },
-  fileFilter,
+  fileFilter: (req, file, cb) => {
+    const ALLOWED_MIME_TYPES = [
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+      "image/gif",
+    ];
+    const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
+    const fileExtension = path.extname(file.originalname).toLowerCase();
+
+    if (
+      !ALLOWED_MIME_TYPES.includes(file.mimetype) ||
+      !ALLOWED_EXTENSIONS.includes(fileExtension)
+    ) {
+      return cb(
+        new Error("Only image files (JPEG, PNG, WebP, GIF) are allowed."),
+        false,
+      );
+    }
+
+    cb(null, true);
+  },
 });
 
 const uploadLimiter = rateLimit({
@@ -90,17 +84,19 @@ const uploadLimiter = rateLimit({
   message: { error: "Upload limit reached, please try again later." },
 });
 
-async function compressImage(filePath, mimetype) {
+async function compressBuffer(buffer, mimetype) {
   // GIFs are skipped — sharp's default pipeline doesn't preserve animation
   if (mimetype === "image/gif") {
-    return { compressed: false };
+    return {
+      compressed: false,
+      buffer,
+      originalSize: buffer.length,
+      newSize: buffer.length,
+    };
   }
 
-  const tempOutputPath = filePath + ".compressed";
-  const originalStats = fs.statSync(filePath);
-
   try {
-    const pipeline = sharp(filePath).resize({
+    const pipeline = sharp(buffer).resize({
       width: 1920,
       height: 1920,
       fit: "inside",
@@ -115,23 +111,31 @@ async function compressImage(filePath, mimetype) {
       pipeline.webp({ quality: 80 });
     }
 
-    await pipeline.toFile(tempOutputPath);
+    const compressedBuffer = await pipeline.toBuffer();
 
-    const compressedStats = fs.statSync(tempOutputPath);
-
-    if (compressedStats.size < originalStats.size) {
-      fs.renameSync(tempOutputPath, filePath);
-      return { compressed: true, originalSize: originalStats.size, newSize: compressedStats.size };
-    } else {
-      fs.unlinkSync(tempOutputPath);
-      return { compressed: false, originalSize: originalStats.size, newSize: originalStats.size };
+    if (compressedBuffer.length < buffer.length) {
+      return {
+        compressed: true,
+        buffer: compressedBuffer,
+        originalSize: buffer.length,
+        newSize: compressedBuffer.length,
+      };
     }
+
+    return {
+      compressed: false,
+      buffer,
+      originalSize: buffer.length,
+      newSize: buffer.length,
+    };
   } catch (err) {
     console.error("[compress] Failed to compress image:", err);
-    if (fs.existsSync(tempOutputPath)) {
-      fs.unlinkSync(tempOutputPath);
-    }
-    return { compressed: false, originalSize: originalStats.size, newSize: originalStats.size };
+    return {
+      compressed: false,
+      buffer,
+      originalSize: buffer.length,
+      newSize: buffer.length,
+    };
   }
 }
 
@@ -141,28 +145,52 @@ router.post(
   uploadLimiter,
   upload.single("file"),
   asyncHandler(async (req, res) => {
+    assertHfConfigured();
+
     if (!req.file) {
       return res.status(400).json({ error: "No file uploaded" });
     }
 
-    const compressionResult = await compressImage(req.file.path, req.file.mimetype);
-    const finalStats = fs.statSync(req.file.path);
+    const compressionResult = await compressBuffer(
+      req.file.buffer,
+      req.file.mimetype,
+    );
 
-    const vaultFile = await VaultFile.create({
-      userId: req.user.id,
-      originalName: req.file.originalname,
-      storedFilename: req.file.filename,
-      size: finalStats.size,
-      mimetype: req.file.mimetype,
+    const sanitizedFilename = sanitizeName(req.file.originalname);
+    const storedFilename =
+      Date.now() +
+      "-" +
+      crypto.randomBytes(4).toString("hex") +
+      "-" +
+      sanitizedFilename;
+    const hfPath = `${req.user.id}/${storedFilename}`;
+
+    await hfUploadFile({
+      repo: HF_REPO_DESIGNATION,
+      accessToken: HF_TOKEN,
+      file: {
+        path: hfPath,
+        content: new Blob([compressionResult.buffer], {
+          type: req.file.mimetype,
+        }),
+      },
     });
 
-    // File is persisted on disk and tracked in the Vault collection — no
-    // cleanup/unlink here. This was the root cause of issue #381.
+    const uploadDoc = await Upload.create({
+      userId: req.user.id,
+      filename: req.file.originalname,
+      hfPath,
+      url: hfPublicUrl(hfPath),
+      mimetype: req.file.mimetype,
+      size: compressionResult.newSize,
+    });
+
     return res.json({
-      filename: vaultFile.originalName,
-      size: vaultFile.size,
-      mimetype: vaultFile.mimetype,
-      path: vaultFile.storedFilename,
+      filename: uploadDoc.filename,
+      size: uploadDoc.size,
+      mimetype: uploadDoc.mimetype,
+      path: uploadDoc.hfPath,
+      url: uploadDoc.url,
       compressed: compressionResult.compressed,
       originalSize: compressionResult.originalSize,
     });
@@ -173,55 +201,90 @@ router.post(
 router.get(
   "/storage-usage",
   asyncHandler(async (req, res) => {
-    const files = await VaultFile.find({ userId: req.user.id }).select("size").lean();
+    const files = await Upload.find({ userId: req.user.id })
+      .select("size")
+      .lean();
     const totalSize = files.reduce((sum, f) => sum + (f.size || 0), 0);
     return res.json({ success: true, totalSize, fileCount: files.length });
   }),
 );
 
 // ── RENAME ──────────────────────────────────────────────────────────────
-// Frontend treats the stored filename as the file's identifier and expects
-// it to change after a rename, so we actually rename the file on disk (and
-// its DB record), rather than just relabeling a display name.
+// Hugging Face has no native rename — we re-upload the file's existing
+// content under a new path, delete the old path, and update the DB record.
 router.patch(
   "/rename/:filename",
   asyncHandler(async (req, res) => {
+    assertHfConfigured();
+
     const { filename } = req.params;
     const { newName } = req.body;
 
     if (!isSafeFilename(filename)) {
-      return res.status(400).json({ success: false, message: "Invalid filename" });
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid filename" });
     }
     if (!newName || typeof newName !== "string" || !newName.trim()) {
-      return res.status(400).json({ success: false, message: "New name is required" });
+      return res
+        .status(400)
+        .json({ success: false, message: "New name is required" });
     }
 
-    const vaultFile = await VaultFile.findOne({
+    const uploadDoc = await Upload.findOne({
       userId: req.user.id,
-      storedFilename: filename,
+      hfPath: `${req.user.id}/${filename}`,
     });
-    if (!vaultFile) {
-      return res.status(404).json({ success: false, message: "File not found" });
+    if (!uploadDoc) {
+      return res
+        .status(404)
+        .json({ success: false, message: "File not found" });
     }
 
     const sanitizedDisplayName = sanitizeName(newName);
     if (!sanitizedDisplayName) {
-      return res.status(400).json({ success: false, message: "Invalid new name" });
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid new name" });
     }
 
+    const fetchRes = await fetch(uploadDoc.url);
+    if (!fetchRes.ok) {
+      return res
+        .status(502)
+        .json({ success: false, message: "Could not read existing file" });
+    }
+    const contentBuffer = Buffer.from(await fetchRes.arrayBuffer());
+
     const newStoredFilename =
-      Date.now() + "-" + crypto.randomBytes(4).toString("hex") + "-" + sanitizedDisplayName;
-    const dir = userVaultDir(req.user.id);
-    const oldPath = path.join(dir, vaultFile.storedFilename);
-    const newPath = path.join(dir, newStoredFilename);
+      Date.now() +
+      "-" +
+      crypto.randomBytes(4).toString("hex") +
+      "-" +
+      sanitizedDisplayName;
+    const newHfPath = `${req.user.id}/${newStoredFilename}`;
 
-    fs.renameSync(oldPath, newPath);
+    await hfUploadFile({
+      repo: HF_REPO_DESIGNATION,
+      accessToken: HF_TOKEN,
+      file: {
+        path: newHfPath,
+        content: new Blob([contentBuffer], { type: uploadDoc.mimetype }),
+      },
+    });
 
-    vaultFile.storedFilename = newStoredFilename;
-    vaultFile.originalName = sanitizedDisplayName;
-    await vaultFile.save();
+    await hfDeleteFiles({
+      repo: HF_REPO_DESIGNATION,
+      accessToken: HF_TOKEN,
+      paths: [uploadDoc.hfPath],
+    });
 
-    return res.json({ success: true, newName: vaultFile.storedFilename });
+    uploadDoc.hfPath = newHfPath;
+    uploadDoc.url = hfPublicUrl(newHfPath);
+    uploadDoc.filename = sanitizedDisplayName;
+    await uploadDoc.save();
+
+    return res.json({ success: true, newName: newStoredFilename });
   }),
 );
 
@@ -229,28 +292,33 @@ router.patch(
 router.delete(
   "/delete/:filename",
   asyncHandler(async (req, res) => {
+    assertHfConfigured();
+
     const { filename } = req.params;
 
     if (!isSafeFilename(filename)) {
-      return res.status(400).json({ success: false, message: "Invalid filename" });
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid filename" });
     }
 
-    const vaultFile = await VaultFile.findOne({
+    const uploadDoc = await Upload.findOne({
       userId: req.user.id,
-      storedFilename: filename,
+      hfPath: `${req.user.id}/${filename}`,
     });
-    if (!vaultFile) {
-      return res.status(404).json({ success: false, message: "File not found" });
+    if (!uploadDoc) {
+      return res
+        .status(404)
+        .json({ success: false, message: "File not found" });
     }
 
-    const filePath = path.join(userVaultDir(req.user.id), vaultFile.storedFilename);
-    fs.unlink(filePath, (err) => {
-      if (err && err.code !== "ENOENT") {
-        console.error(`[vault] Failed to delete file ${filePath}:`, err);
-      }
+    await hfDeleteFiles({
+      repo: HF_REPO_DESIGNATION,
+      accessToken: HF_TOKEN,
+      paths: [uploadDoc.hfPath],
     });
 
-    await VaultFile.deleteOne({ _id: vaultFile._id });
+    await Upload.deleteOne({ _id: uploadDoc._id });
 
     return res.json({ success: true });
   }),


### PR DESCRIPTION
## 📝 Description
Swaps the File Upload system's storage backend from local disk to Hugging Face, per #962. Files are now buffered in memory, optionally compressed (images), uploaded to a Hugging Face dataset repo, and tracked via a new `Upload` model — replacing the previous `VaultFile`/local-disk implementation.

## 🔗 Related Issues
closes #962

## 📋 Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔄 Breaking change (fix or feature that would cause existing functionality to change)

## 🔄 Changes Made
- Replaced `multer.diskStorage` + `VaultFile` with `multer.memoryStorage()` + new `Upload` model (`model/upload.js`)
- `POST /upload` now uploads the file buffer to a Hugging Face dataset repo via `@huggingface/hub`'s `uploadFile`, instead of writing to local disk
- Image compression (`sharp`) now operates on the in-memory buffer rather than a file path
- `PATCH /rename/:filename`: since Hugging Face has no native rename, this re-uploads the file's content under a new path and deletes the old one
- `DELETE /delete/:filename` now removes the file from the HF repo via `deleteFiles`, plus the DB record
- `GET /storage-usage` now sums from the `Upload` collection
- Added `@huggingface/hub` dependency

## ✅ Testing
### How to Test
1. Set `HF_TOKEN` and `HF_DATASET_REPO` in `.env.local` (a dataset repo you control)
2. Log in, go to File Upload, upload an image — confirm it appears on the Hugging Face repo under `<userId>/<filename>` and the returned `url` resolves
3. Rename and delete the file — confirm the old path is removed from the HF repo and a renamed/deleted file no longer resolves at its old URL

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 🚀 Deployment Notes
- Requires two new env vars: `HF_TOKEN` (Hugging Face access token with write access) and `HF_DATASET_REPO` (e.g. `org/creatoros-uploads`)
- Existing files previously stored via the local-disk Vault system (`VaultFile`/`uploads/vault/`) are **not migrated** — they'll need a separate migration script if that data must be preserved

## ⚠️ Breaking Changes
- Storage backend change is breaking for any existing local-disk uploads (see Deployment Notes above — no migration included in this PR)
- `VaultFile` model is no longer written to by this route; can be removed in a follow-up once migration is confirmed unnecessary or complete

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Scope note: the issue's Technical Requirements list "chunk uploads" and "retry failed uploads" — this PR does **not** implement chunking (still single-shot, capped at 50MB via multer's existing limit). Chunked upload support for large files would be a solid fast-follow if maintainers want it split out.

Also flagging: `routes/fileUpload.js` previously backed the local-disk "Vault" feature. I'm treating #962 as replacing that backend rather than adding a parallel uploader — happy to adjust if that wasn't the intended scope.