### PR TITLE
fix: correct linkedAt fallback in serializeLink to use entry.createdAt

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -165,7 +165,7 @@ function formatClicks(count) {
  */
 function serializeLink(entry, hostBase) {
   const linkedAt =
-    entry.linkedAt || entry.createdAt?.[0]?.timeStamp || new Date();
+    entry.linkedAt || entry.createdAt || new Date();
   return {
     shortId: entry.shortId,
     redirectUrl: entry.redirectUrl,


### PR DESCRIPTION
## 📝 Description
Fixes the broken `linkedAt` fallback chain in `serializeLink` (controller/url.js) that caused links created via the HTML form to always display the current date instead of their actual creation date.

`entry.createdAt` is a Date, not an array, so the previous fallback chain (`entry.createdAt?.[0]?.timeStamp`) always evaluated to `undefined`, causing links created via the HTML form (which don't set `linkedAt` at creation) to always fall through to `new Date()`. This made My Links display the current date instead of the actual creation date for those links.

## 🔗 Related Issues
closes #1037

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔄 Changes Made
- Updated the `linkedAt` fallback in `serializeLink` (controller/url.js) to use `entry.createdAt` directly instead of the broken `entry.createdAt?.[0]?.timeStamp` array access
- `new Date()` retained only as a final safety net

## ✅ Testing
### How to Test
1. Create a link via the HTML form (`POST /services/url-shortener/shorten`)
2. Wait, or manually check the stored `createdAt`
3. Load My Links (`GET /api/urls`) and confirm the displayed date matches the actual creation date, not today's date

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
N/A — backend logic fix, no UI changes

## 🚀 Deployment Notes
None — no schema or migration changes required.

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Root cause and reproduction steps were documented in detail in #1037 by the reporter. Minimal one-line fix in `serializeLink` covers both the HTML-form path and stays backward-compatible with the API path, which already sets `linkedAt` explicitly.

---
**Thank you for contributing to CreatorOS!** 🙌