### PR TITLE
feat(observability): add /health and /metrics endpoints with Docker healthcheck and Nginx config (#1023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - [🛠️ Tech Stack](#%EF%B8%8F-tech-stack)
 - [🚀 Getting Started](#-getting-started)
 - [📁 Project Structure](#-project-structure)
+- [📈 Observability & Monitoring](#-observability--monitoring)
 - [🎯 Who Is This For?](#-who-is-this-for)
 - [💰 Pricing Model](#-pricing-model)
 - [🗺️ Roadmap](#%EF%B8%8F-roadmap)
@@ -433,6 +434,59 @@ CreatorOS/
 ├── 📂 utils/                  # Utility functions & helpers
 ├── 📂 public/                 # Static assets (CSS, JS, images)
 └── 📂 tests/                  # Test suites
+```
+
+---
+
+## 📈 Observability & Monitoring
+
+CreatorOS includes dedicated endpoints for production health checks, container probes, load balancers, and metrics scrapers.
+
+### Health Endpoint (`/health`)
+
+Used by Railway health probes, Nginx passive health checks, Docker healthcheck stanzas, and external uptime monitors (e.g., UptimeRobot, BetterStack).
+
+- **Endpoint**: `GET /health`
+- **Authentication**: Unauthenticated (bypasses CSRF & session auth)
+- **Status Codes**:
+  - `200 OK`: Database connected (or running in mock DB mode)
+  - `503 Service Unavailable`: Database disconnected or degraded
+
+**Sample Response (`200 OK`)**:
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-08-14T15:30:00.000Z",
+  "uptime": 3600,
+  "database": "connected",
+  "redis": "connected",
+  "version": "1.0.0",
+  "memory": {
+    "rssMb": 45.2,
+    "heapTotalMb": 32.1,
+    "heapUsedMb": 24.5
+  }
+}
+```
+
+### Metrics Endpoint (`/metrics`)
+
+Exposes process, system, and database operational metrics for monitoring tools (e.g., Prometheus, Grafana, Datadog).
+
+- **Endpoint**: `GET /metrics`
+- **Formats**:
+  - **Prometheus Text Format (Default)**: `text/plain; version=0.0.4`
+  - **JSON Format**: Send `Accept: application/json` or append `?format=json`
+
+**Sample Prometheus Text Output**:
+```text
+# HELP process_uptime_seconds Process uptime in seconds.
+# TYPE process_uptime_seconds gauge
+process_uptime_seconds 3600
+
+# HELP creatoros_database_connected Database connection status (1 = connected, 0 = disconnected).
+# TYPE creatoros_database_connected gauge
+creatoros_database_connected 1
 ```
 
 ---

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,6 +63,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))\""]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     networks:
       - app-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,12 @@ services:
     depends_on:
       - mongodb
       - redis
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
     networks:
       - app-network
 

--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ const smartNotificationRoutes = require("./routes/smartNotificationRoutes");
 const contentOsRoutes = require("./routes/contentOsRoutes");
 const creatorCrmRoutes = require("./routes/creatorCrmRoutes");
 const meetingRoutes = require("./routes/meetingRoutes");
+const healthRoutes = require("./routes/health");
 const { generateCsrf, verifyCsrf } = require("./middleware/csrf");
 
 // Generate a per-request nonce before Helmet so early exits (CSRF/validation)
@@ -155,6 +156,9 @@ app.use((req, res, next) => {
   });
   next();
 });
+// Observability endpoints (/health, /metrics) must be mounted before CSRF middleware
+app.use("/", healthRoutes);
+
 // Instagram webhook must be mounted before the global CSRF middleware so Meta
 // callbacks (which carry no _csrf cookie) are verified by HMAC signature only.
 app.get("/api/instagram/webhook", verifyWebhook);

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -38,7 +38,7 @@ http {
     upstream web_app {
         # Using least_conn algorithm for balancing active connections
         least_conn;
-        server web:3000;
+        server web:3000 max_fails=3 fail_timeout=10s;
     }
 
     server {
@@ -53,6 +53,28 @@ http {
         add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
+
+        # Health check probe location for uptime monitoring & load balancers
+        location = /health {
+            proxy_pass http://web_app/health;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            access_log off;
+        }
+
+        # Metrics scraper location for Prometheus & monitoring services
+        location = /metrics {
+            proxy_pass http://web_app/metrics;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            access_log off;
+        }
 
         location / {
             proxy_pass http://web_app;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon index.js",
     "start": "node index.js",
-    "build": "npm run build:css && node --check index.js && node --check controller/auth.js && node --check routes/auth.js && node --check model/user.js && node --check model/notification.js && node --check controller/smartNotificationController.js && node --check routes/smartNotificationRoutes.js && node --check workers/contentPublishWorker.js && node --check services/dmQueueService.js && node --check controller/meetingController.js && node --check routes/meetingRoutes.js && node --check model/eventType.js && node --check model/meetingBooking.js && node --check services/googleCalendarService.js",
+    "build": "npm run build:css && node --check index.js && node --check controller/auth.js && node --check routes/auth.js && node --check model/user.js && node --check model/notification.js && node --check controller/smartNotificationController.js && node --check routes/smartNotificationRoutes.js && node --check workers/contentPublishWorker.js && node --check services/dmQueueService.js && node --check controller/meetingController.js && node --check routes/meetingRoutes.js && node --check model/eventType.js && node --check model/meetingBooking.js && node --check services/googleCalendarService.js && node --check routes/health.js",
     "seed:test-user": "node scripts/seedTestUser.js",
     "build:css": "tailwindcss -i ./public/css/input.css -o ./public/css/style.css --minify",
     "watch:css": "tailwindcss -i ./public/css/input.css -o ./public/css/style.css --watch",

--- a/routes/health.js
+++ b/routes/health.js
@@ -1,0 +1,142 @@
+const express = require("express");
+const mongoose = require("mongoose");
+const packageJson = require("../package.json");
+const { hasRedisConfig, createRedisClient } = require("../utils/redisClient");
+
+const router = express.Router();
+
+/**
+ * GET /health
+ * Diagnostic health check endpoint for production uptime monitoring,
+ * load balancers (Nginx), and Railway container probes.
+ */
+router.get("/health", async (req, res) => {
+  const dbState = mongoose.connection.readyState;
+  const isMockDb = process.env.USE_MOCK_DB === "true";
+
+  let dbStatus = "disconnected";
+  if (isMockDb) {
+    dbStatus = "mock";
+  } else if (dbState === 1) {
+    dbStatus = "connected";
+  } else if (dbState === 2) {
+    dbStatus = "connecting";
+  } else if (dbState === 3) {
+    dbStatus = "disconnecting";
+  }
+
+  const isHealthy = dbState === 1 || isMockDb;
+
+  let redisStatus = "not_configured";
+  if (hasRedisConfig()) {
+    try {
+      const redisClient = createRedisClient();
+      if (redisClient) {
+        if (redisClient.status === "ready" || redisClient.status === "connect") {
+          redisStatus = "connected";
+        } else {
+          redisStatus = "configured";
+        }
+        if (typeof redisClient.quit === "function") {
+          redisClient.quit().catch(() => {});
+        }
+      }
+    } catch (err) {
+      redisStatus = "error";
+    }
+  }
+
+  const memory = process.memoryUsage();
+
+  const status = {
+    status: isHealthy ? "ok" : "degraded",
+    timestamp: new Date().toISOString(),
+    uptime: Math.floor(process.uptime()),
+    database: dbStatus,
+    redis: redisStatus,
+    version: process.env.npm_package_version || packageJson.version || "1.0.0",
+    memory: {
+      rssMb: Math.round((memory.rss / (1024 * 1024)) * 100) / 100,
+      heapTotalMb: Math.round((memory.heapTotal / (1024 * 1024)) * 100) / 100,
+      heapUsedMb: Math.round((memory.heapUsed / (1024 * 1024)) * 100) / 100,
+    },
+  };
+
+  const httpStatus = isHealthy ? 200 : 503;
+  res.status(httpStatus).json(status);
+});
+
+/**
+ * GET /metrics
+ * Metrics endpoint for production observability.
+ * Supports Prometheus text exposition format (default) and JSON format.
+ */
+router.get("/metrics", async (req, res) => {
+  const isMockDb = process.env.USE_MOCK_DB === "true";
+  const dbConnected = mongoose.connection.readyState === 1 || isMockDb ? 1 : 0;
+  const redisConfigured = hasRedisConfig() ? 1 : 0;
+  const memory = process.memoryUsage();
+  const cpu = process.cpuUsage();
+  const uptime = process.uptime();
+
+  const acceptsJson =
+    req.query.format === "json" ||
+    (req.headers.accept && req.headers.accept.includes("application/json"));
+
+  if (acceptsJson) {
+    return res.json({
+      uptime_seconds: uptime,
+      process_cpu_user_seconds: cpu.user / 1e6,
+      process_cpu_system_seconds: cpu.system / 1e6,
+      memory_bytes: {
+        rss: memory.rss,
+        heapTotal: memory.heapTotal,
+        heapUsed: memory.heapUsed,
+        external: memory.external || 0,
+      },
+      database_connected: dbConnected,
+      redis_configured: redisConfigured,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  const metricsText = [
+    "# HELP process_uptime_seconds Process uptime in seconds.",
+    "# TYPE process_uptime_seconds gauge",
+    `process_uptime_seconds ${uptime}`,
+    "",
+    "# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.",
+    "# TYPE process_cpu_user_seconds_total counter",
+    `process_cpu_user_seconds_total ${(cpu.user / 1e6).toFixed(6)}`,
+    "",
+    "# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.",
+    "# TYPE process_cpu_system_seconds_total counter",
+    `process_cpu_system_seconds_total ${(cpu.system / 1e6).toFixed(6)}`,
+    "",
+    "# HELP nodejs_heap_size_total_bytes Process memory heap total bytes.",
+    "# TYPE nodejs_heap_size_total_bytes gauge",
+    `nodejs_heap_size_total_bytes ${memory.heapTotal}`,
+    "",
+    "# HELP nodejs_heap_size_used_bytes Process memory heap used bytes.",
+    "# TYPE nodejs_heap_size_used_bytes gauge",
+    `nodejs_heap_size_used_bytes ${memory.heapUsed}`,
+    "",
+    "# HELP nodejs_external_memory_bytes Process external memory bytes.",
+    "# TYPE nodejs_external_memory_bytes gauge",
+    `nodejs_external_memory_bytes ${memory.external || 0}`,
+    "",
+    "# HELP creatoros_database_connected Database connection status (1 = connected, 0 = disconnected).",
+    "# TYPE creatoros_database_connected gauge",
+    `creatoros_database_connected ${dbConnected}`,
+    "",
+    "# HELP creatoros_redis_configured Redis configuration status (1 = configured, 0 = not configured).",
+    "# TYPE creatoros_redis_configured gauge",
+    `creatoros_redis_configured ${redisConfigured}`,
+    "",
+  ].join("\n");
+
+  res.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+  res.send(metricsText);
+});
+
+module.exports = router;

--- a/tests/routes/healthAndMetrics.test.js
+++ b/tests/routes/healthAndMetrics.test.js
@@ -1,0 +1,119 @@
+const express = require("express");
+const request = require("supertest");
+const mongoose = require("mongoose");
+const fs = require("fs");
+const path = require("path");
+const healthRoutes = require("../../routes/health");
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/", healthRoutes);
+  return app;
+}
+
+describe("Health and Metrics Routes", () => {
+  const originalEnv = process.env.USE_MOCK_DB;
+
+  afterEach(() => {
+    process.env.USE_MOCK_DB = originalEnv;
+    delete mongoose.connection.readyState;
+  });
+
+  describe("GET /health", () => {
+    it("returns HTTP 200 and ok status when USE_MOCK_DB is true", async () => {
+      process.env.USE_MOCK_DB = "true";
+      const app = createApp();
+      const res = await request(app).get("/health");
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.status).toBe("ok");
+      expect(res.body.database).toBe("mock");
+      expect(res.body).toHaveProperty("timestamp");
+      expect(res.body).toHaveProperty("uptime");
+      expect(res.body).toHaveProperty("version");
+      expect(res.body).toHaveProperty("memory");
+      expect(res.body.memory).toHaveProperty("rssMb");
+      expect(res.body.memory).toHaveProperty("heapUsedMb");
+    });
+
+    it("returns HTTP 503 and degraded status when database is disconnected", async () => {
+      delete process.env.USE_MOCK_DB;
+      Object.defineProperty(mongoose.connection, "readyState", {
+        get: () => 0,
+        configurable: true,
+      });
+
+      const app = createApp();
+      const res = await request(app).get("/health");
+
+      expect(res.statusCode).toBe(503);
+      expect(res.body.status).toBe("degraded");
+      expect(res.body.database).toBe("disconnected");
+    });
+
+    it("returns HTTP 200 and ok status when mongoose.connection.readyState is 1", async () => {
+      delete process.env.USE_MOCK_DB;
+      Object.defineProperty(mongoose.connection, "readyState", {
+        get: () => 1,
+        configurable: true,
+      });
+
+      const app = createApp();
+      const res = await request(app).get("/health");
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.status).toBe("ok");
+      expect(res.body.database).toBe("connected");
+    });
+  });
+
+  describe("GET /metrics", () => {
+    it("returns Prometheus text metrics by default", async () => {
+      const app = createApp();
+      const res = await request(app).get("/metrics");
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-type"]).toContain("text/plain");
+      expect(res.text).toContain("process_uptime_seconds");
+      expect(res.text).toContain("creatoros_database_connected");
+      expect(res.text).toContain("nodejs_heap_size_used_bytes");
+    });
+
+    it("returns JSON metrics when format=json query parameter is passed", async () => {
+      const app = createApp();
+      const res = await request(app).get("/metrics?format=json");
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-type"]).toContain("application/json");
+      expect(res.body).toHaveProperty("uptime_seconds");
+      expect(res.body).toHaveProperty("memory_bytes");
+      expect(res.body).toHaveProperty("database_connected");
+      expect(res.body).toHaveProperty("redis_configured");
+    });
+
+    it("returns JSON metrics when Accept header includes application/json", async () => {
+      const app = createApp();
+      const res = await request(app)
+        .get("/metrics")
+        .set("Accept", "application/json");
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-type"]).toContain("application/json");
+      expect(res.body).toHaveProperty("uptime_seconds");
+      expect(res.body).toHaveProperty("database_connected");
+    });
+  });
+
+  describe("index.js Route Mounting Verification", () => {
+    it("mounts healthRoutes before generateCsrf middleware in index.js", () => {
+      const source = fs.readFileSync(path.join(__dirname, "../../index.js"), "utf8");
+      const healthMountIndex = source.indexOf("app.use(\"/\", healthRoutes)");
+      const csrfMountIndex = source.indexOf("app.use(generateCsrf)");
+
+      expect(healthMountIndex).toBeGreaterThan(-1);
+      expect(csrfMountIndex).toBeGreaterThan(-1);
+      expect(healthMountIndex).toBeLessThan(csrfMountIndex);
+    });
+  });
+});


### PR DESCRIPTION
## 📝 Description
This PR introduces production observability and uptime monitoring capabilities for CreatorOS by implementing dedicated `/health` and `/metrics` endpoints. It integrates container healthchecks into `docker-compose`, configures Nginx upstream probes, documents the new endpoints in `README.md`, and includes a unit/integration test suite.

## 🔗 Related Issues

Fixes #1023

## 📋 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [x] 🧪 Test update

## 🔄 Changes Made

- Created `routes/health.js` containing `GET /health` (diagnostic health status, Mongoose DB connection state, process uptime, memory usage) and `GET /metrics` (Prometheus text format by default, JSON format via `Accept: application/json` or `?format=json`).
- Mounted `healthRoutes` in `index.js` prior to CSRF protection (`generateCsrf` and `verifyCsrf`) so uptime checkers and container probes can poll endpoints without requiring session cookies or CSRF tokens.
- Added `healthcheck` stanzas to the `web` application service in `docker-compose.yml` and `docker-compose.dev.yml`.
- Configured dedicated `location = /health` and `location = /metrics` blocks with `access_log off` and upstream passive health checks (`max_fails=3 fail_timeout=10s`) in `nginx/nginx.conf`.
- Updated `package.json` build script to include syntax check for `routes/health.js`.
- Added a `## 📈 Observability & Monitoring` section and updated the Table of Contents in `README.md`.
- Created unit & integration test suite `tests/routes/healthAndMetrics.test.js` covering HTTP 200/503 status code semantics, payload schemas, Prometheus text & JSON metric formatting, and CSRF middleware ordering.

## ✅ Testing

### How to Test

1. Start the server using `npm run start` or `npm run dev`.
2. Test the health endpoint: `curl http://localhost:3000/health` (verify HTTP 200 OK, JSON structure with status, database state, process uptime, and memory usage).
3. Test the metrics endpoint:
   - Prometheus format: `curl http://localhost:3000/metrics`
   - JSON format: `curl -H "Accept: application/json" http://localhost:3000/metrics`
4. Run the automated test suite: `npm test tests/routes/healthAndMetrics.test.js`.

### Test Coverage
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)

N/A (Backend observability endpoints)

## 🚀 Deployment Notes

No special deployment steps required. Compatible out-of-the-box with Railway health probes, external uptime checkers (UptimeRobot, BetterStack), Nginx load balancers, and Prometheus metric scrapers.

## ⚠️ Breaking Changes

- None

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context

Endpoints bypass CSRF verification and session authentication by design to ensure standard monitoring tools (Prometheus scrapers, load balancer health probes, container healthchecks) can access `/health` and `/metrics` unhindered.

---

**Thank you for contributing to CreatorOS!** 🙌
